### PR TITLE
npmワークフローの修正

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       packages: write
       contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
           scope: '@furutsubaki'
@@ -33,5 +34,3 @@ jobs:
 
       - run: pnpm build
       - run: pnpm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minazuki-ui",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "private": false,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
npm にてクラシックトークンが廃止されたため、OIDC認証に変更