### PR TITLE
feat: ツリーシェイキング対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "README.md",
     "LICENSE"
   ],
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "require": "./dist/index.umd.cjs",
+      "types": "./dist/index.d.ts"
     },
     "./dist/style.css": "./dist/style.css"
   },
@@ -49,30 +51,22 @@
   },
   "peerDependencies": {
     "@acab/reset.css": "^0.11",
+    "@unhead/vue": "^1",
     "@vee-validate/rules": "^4",
     "@vee-validate/zod": "^4",
+    "@vuepic/vue-datepicker": "^11",
+    "dayjs": "^1",
     "i18next": "^23",
+    "lucide-vue-next": ">=0.356.0",
     "pinia": "^2",
     "vee-validate": "^4",
     "vue": "^3",
+    "vue-router": "^4",
     "zod": "^3",
     "zod-i18n-map": "^2"
   },
   "dependencies": {
-    "@acab/reset.css": "^0.11.0",
-    "@unhead/vue": "^1.11.20",
-    "@vee-validate/rules": "^4.13.2",
-    "@vee-validate/zod": "^4.14.7",
-    "@vuepic/vue-datepicker": "^11.0.2",
-    "dayjs": "^1.11.11",
-    "i18next": "^23.12.2",
-    "lucide-vue-next": "^0.356.0",
-    "pinia": "^2.2.2",
-    "vee-validate": "^4.13.2",
-    "vue": "^3.4.27",
-    "vue-router": "^4.5.1",
-    "zod": "^3.23.8",
-    "zod-i18n-map": "^2.27.0"
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.10.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,46 +9,49 @@ importers:
   .:
     dependencies:
       '@acab/reset.css':
-        specifier: ^0.11.0
+        specifier: ^0.11
         version: 0.11.0
       '@unhead/vue':
-        specifier: ^1.11.20
+        specifier: ^1
         version: 1.11.20(vue@3.4.27(typescript@5.8.3))
       '@vee-validate/rules':
-        specifier: ^4.13.2
+        specifier: ^4
         version: 4.13.2(vue@3.4.27(typescript@5.8.3))
       '@vee-validate/zod':
-        specifier: ^4.14.7
+        specifier: ^4
         version: 4.14.7(vue@3.4.27(typescript@5.8.3))
       '@vuepic/vue-datepicker':
-        specifier: ^11.0.2
+        specifier: ^11
         version: 11.0.2(vue@3.4.27(typescript@5.8.3))
       dayjs:
-        specifier: ^1.11.11
+        specifier: ^1
         version: 1.11.11
       i18next:
-        specifier: ^23.12.2
+        specifier: ^23
         version: 23.12.2
+      lodash.merge:
+        specifier: ^4.6.2
+        version: 4.6.2
       lucide-vue-next:
-        specifier: ^0.356.0
+        specifier: '>=0.356.0'
         version: 0.356.0(vue@3.4.27(typescript@5.8.3))
       pinia:
-        specifier: ^2.2.2
+        specifier: ^2
         version: 2.2.2(typescript@5.8.3)(vue@3.4.27(typescript@5.8.3))
       vee-validate:
-        specifier: ^4.13.2
-        version: 4.13.2(vue@3.4.27(typescript@5.8.3))
+        specifier: ^4
+        version: 4.14.7(vue@3.4.27(typescript@5.8.3))
       vue:
-        specifier: ^3.4.27
+        specifier: ^3
         version: 3.4.27(typescript@5.8.3)
       vue-router:
-        specifier: ^4.5.1
+        specifier: ^4
         version: 4.5.1(vue@3.4.27(typescript@5.8.3))
       zod:
-        specifier: ^3.23.8
+        specifier: ^3
         version: 3.23.8
       zod-i18n-map:
-        specifier: ^2.27.0
+        specifier: ^2
         version: 2.27.0(i18next@23.12.2)(zod@3.23.8)
     devDependencies:
       '@rushstack/eslint-patch':
@@ -123,9 +126,6 @@ importers:
       lint-staged:
         specifier: ^15.2.2
         version: 15.2.2
-      lodash.merge:
-        specifier: ^4.6.2
-        version: 4.6.2
       npm-run-all2:
         specifier: ^6.2.2
         version: 6.2.2
@@ -188,10 +188,6 @@ packages:
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.24.7':
-    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.24.8':
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
@@ -204,11 +200,6 @@ packages:
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.24.6':
-    resolution: {integrity: sha512-eNZXdfU35nJC2h24RznROuOpO94h6x8sg9ju0tT9biNtLZ2vuP8SduLqqV+/8+cebSLV9SJEAN5Z3zQbJG/M+Q==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.25.4':
     resolution: {integrity: sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==}
     engines: {node: '>=6.0.0'}
@@ -216,10 +207,6 @@ packages:
 
   '@babel/runtime@7.23.8':
     resolution: {integrity: sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.24.7':
-    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.25.4':
@@ -516,46 +503,55 @@ packages:
     resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.0':
     resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.18.0':
     resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.0':
     resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.18.0':
     resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.18.0':
     resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.18.0':
     resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
@@ -925,9 +921,6 @@ packages:
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
-
-  '@vue/devtools-api@6.6.3':
-    resolution: {integrity: sha512-0MiMsFma/HqA6g3KLKn+AGpL1kgKhFWszC9U29NfpWK5LE7bjeXxySWJrOJ77hBz+TBrBQ7o4QJqbPbqbs8rJw==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -2628,8 +2621,8 @@ packages:
   vue-component-type-helpers@2.0.29:
     resolution: {integrity: sha512-58i+ZhUAUpwQ+9h5Hck0D+jr1qbYl4voRt5KffBx8qzELViQ4XdT/Tuo+mzq8u63teAG8K0lLaOiL5ofqW38rg==}
 
-  vue-component-type-helpers@2.2.10:
-    resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
+  vue-component-type-helpers@3.2.7:
+    resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -2782,8 +2775,6 @@ snapshots:
       '@babel/highlight': 7.24.7
       picocolors: 1.0.0
 
-  '@babel/helper-string-parser@7.24.7': {}
-
   '@babel/helper-string-parser@7.24.8': {}
 
   '@babel/helper-validator-identifier@7.24.7': {}
@@ -2795,10 +2786,6 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.0.0
 
-  '@babel/parser@7.24.6':
-    dependencies:
-      '@babel/types': 7.24.7
-
   '@babel/parser@7.25.4':
     dependencies:
       '@babel/types': 7.25.4
@@ -2806,12 +2793,6 @@ snapshots:
   '@babel/runtime@7.23.8':
     dependencies:
       regenerator-runtime: 0.14.1
-
-  '@babel/types@7.24.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
 
   '@babel/types@7.25.4':
     dependencies:
@@ -3259,7 +3240,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.27(typescript@5.8.3)
-      vue-component-type-helpers: 2.2.10
+      vue-component-type-helpers: 3.2.7
 
   '@stylistic/eslint-plugin@4.2.0(eslint@8.57.0)(typescript@5.8.3)':
     dependencies:
@@ -3543,15 +3524,15 @@ snapshots:
 
   '@vue/compiler-sfc@3.4.27':
     dependencies:
-      '@babel/parser': 7.24.6
+      '@babel/parser': 7.25.4
       '@vue/compiler-core': 3.4.27
       '@vue/compiler-dom': 3.4.27
       '@vue/compiler-ssr': 3.4.27
       '@vue/shared': 3.4.27
       estree-walker: 2.0.2
       magic-string: 0.30.10
-      postcss: 8.4.38
-      source-map-js: 1.2.0
+      postcss: 8.5.3
+      source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.4.27':
     dependencies:
@@ -3562,8 +3543,6 @@ snapshots:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
-
-  '@vue/devtools-api@6.6.3': {}
 
   '@vue/devtools-api@6.6.4': {}
 
@@ -4680,7 +4659,7 @@ snapshots:
 
   pinia@2.2.2(typescript@5.8.3)(vue@3.4.27(typescript@5.8.3)):
     dependencies:
-      '@vue/devtools-api': 6.6.3
+      '@vue/devtools-api': 6.6.4
       vue: 3.4.27(typescript@5.8.3)
       vue-demi: 0.14.10(vue@3.4.27(typescript@5.8.3))
     optionalDependencies:
@@ -5243,7 +5222,7 @@ snapshots:
 
   vee-validate@4.13.2(vue@3.4.27(typescript@5.8.3)):
     dependencies:
-      '@vue/devtools-api': 6.6.3
+      '@vue/devtools-api': 6.6.4
       type-fest: 4.38.0
       vue: 3.4.27(typescript@5.8.3)
 
@@ -5294,7 +5273,7 @@ snapshots:
 
   vue-component-type-helpers@2.0.29: {}
 
-  vue-component-type-helpers@2.2.10: {}
+  vue-component-type-helpers@3.2.7: {}
 
   vue-demi@0.14.10(vue@3.4.27(typescript@5.8.3)):
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,23 +6,75 @@ import vue from '@vitejs/plugin-vue'
 import dts from 'vite-plugin-dts'
 import postcssNesting from "postcss-nesting";
 
+const externalPackages = [
+    'vue',
+    'unhead',
+    '@unhead/vue',
+    '@acab/reset.css',
+    '@vee-validate/rules',
+    '@vee-validate/zod',
+    '@vuepic/vue-datepicker',
+    'dayjs',
+    'i18next',
+    'lodash.merge',
+    'lucide-vue-next',
+    'pinia',
+    'vee-validate',
+    'vue-router',
+    'zod',
+    'zod-i18n-map',
+];
+
+const externalRegexps = externalPackages.map(
+    (pkg) => new RegExp(`^${pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(/.*)?$`)
+);
+
 export default defineConfig({
     build: {
         lib: {
             entry: resolve(__dirname, './src/index.ts'),
             name: 'minazuki-ui',
-            fileName: 'index',
-            formats: ['es', 'umd']
         },
         rollupOptions: {
-            external: ['vue','unhead'],
-            output: {
-                globals: {
-                    vue: 'Vue'
+            external: externalRegexps,
+            output: [
+                {
+                    // Tree-shakable ES Modules
+                    format: 'es',
+                    dir: './dist',
+                    preserveModules: true,
+                    preserveModulesRoot: 'src',
+                    entryFileNames: '[name].js',
+                    exports: 'named',
                 },
-                exports: 'named'
-            },
-        }
+                {
+                    // UMD single bundle (legacy / CDN)
+                    format: 'umd',
+                    dir: './dist',
+                    name: 'minazuki-ui',
+                    entryFileNames: 'index.umd.cjs',
+                    exports: 'named',
+                    globals: {
+                        'vue': 'Vue',
+                        'unhead': 'Unhead',
+                        '@unhead/vue': 'UnheadVue',
+                        '@acab/reset.css': 'AcabResetCss',
+                        '@vee-validate/rules': 'VeeValidateRules',
+                        '@vee-validate/zod': 'VeeValidateZod',
+                        '@vuepic/vue-datepicker': 'VueDatePicker',
+                        'dayjs': 'dayjs',
+                        'i18next': 'i18next',
+                        'lodash.merge': '_merge',
+                        'lucide-vue-next': 'LucideVueNext',
+                        'pinia': 'Pinia',
+                        'vee-validate': 'VeeValidate',
+                        'vue-router': 'VueRouter',
+                        'zod': 'Zod',
+                        'zod-i18n-map': 'ZodI18nMap',
+                    },
+                },
+            ],
+        },
     },
     plugins: [
         vue(),


### PR DESCRIPTION
## Summary

- `vite.config.ts` に `preserveModules: true` を追加し、ESM出力を各コンポーネントの独立ファイルに分割
- `external` を全 peerDependencies に拡充し、`lucide-vue-next` 等の重量級ライブラリをバンドルから除外
- `package.json` に `"sideEffects": false` を追加し、バンドラーがツリーシェイキング可能と認識するよう設定
- `peerDependencies` に不足パッケージ (`@unhead/vue`, `@vuepic/vue-datepicker`, `lucide-vue-next`, `vue-router`, `dayjs`) を追加
- `dependencies` から `peerDependencies` との重複を削除し、二重インストール・複数Vueインスタンス問題を防止

- https://github.com/furutsubaki/minazuki-ui/issues/596

## Bundle size

| | Before | After |
|---|---|---|
| `dist/index.js` (ESM) | 549 KB（単一バンドル） | **4.4 KB**（エントリのみ） |
| `dist/index.umd.cjs` | 402 KB | **75 KB** |

## Test plan

- [x] `pnpm build` が正常完了することを確認
- [x] 消費側プロジェクトで `import { MiButton } from 'minazuki-ui'` のみインポートし、バンドルサイズが削減されることを確認
- [x] `import 'minazuki-ui/dist/style.css'` でスタイルが適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)