### PR TITLE
chore: Claude Code設定ファイルを更新

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,27 @@
     "pr": "Generated with [Claude Code](https://claude.ai/code)"
   },
   "permissions": {
+    "allow": [
+      "Edit(*)",
+      "Write(*)",
+      "NotebookEdit(*)",
+      "Bash(*)",
+      "WebFetch(domain:*)",
+      "WebSearch",
+      "mcp__*",
+      "mcp__ide__*",
+      "mcp__chrome-devtools__*",
+      "mcp__claude-in-chrome__*",
+      "mcp__playwright__*",
+      "mcp__reddit-mcp-server__search_reddit",
+      "mcp__reddit-mcp-server__get_post_details",
+      "mcp__tavily-web-search__tavily_search",
+      "mcp__tavily-web-search__tavily_extract",
+      "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:support.claude.com)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:api.github.com)"
+    ],
     "deny": [
       "Read(.env)",
       "Read(*.env)",
@@ -47,34 +68,13 @@
       "Bash(kill *)",
       "Bash(killall *)",
       "Bash(pkill *)"
-    ],
-    "allow": [
-      "Edit(*)",
-      "Write(*)",
-      "NotebookEdit(*)",
-      "Bash(*)",
-      "WebFetch(domain:*)",
-      "WebSearch",
-      "mcp__*",
-      "mcp__ide__*",
-      "mcp__chrome-devtools__*",
-      "mcp__claude-in-chrome__*",
-      "mcp__playwright__*",
-      "mcp__reddit-mcp-server__search_reddit",
-      "mcp__reddit-mcp-server__get_post_details",
-      "mcp__tavily-web-search__tavily_search",
-      "mcp__tavily-web-search__tavily_extract",
-      "WebFetch(domain:docs.anthropic.com)",
-      "WebFetch(domain:support.claude.com)",
-      "WebFetch(domain:github.com)",
-      "WebFetch(domain:api.github.com)"
     ]
   },
   "enableAllProjectMcpServers": true,
-  "hooks": {
-  },
+  "hooks": {},
   "disableAllHooks": false,
   "enabledPlugins": {
-    "context7@claude-plugins-official": true
+    "context7@claude-plugins-official": true,
+    "github@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary

- `permissions` の `allow` / `deny` の記述順を `allow` が先になるよう整理
- `hooks` の空オブジェクト記法をインライン形式に統一
- `enabledPlugins` に `github@claude-plugins-official` を追加

## Test plan

- [x] `.claude/settings.json` の JSON が正常にパースされること
- [x] `pnpm lint` がパスすること

Generated with [Claude Code](https://claude.ai/code)