### PR TITLE
perf: Plugin install - globalProperties と provide の重複を削除

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,14 +23,6 @@ type RecursivePartial<T> = {
     [P in keyof T]?: RecursivePartial<T[P]>;
 };
 
-declare module 'vue' {
-    interface NuxtApp {
-        $useFormData: ReturnType<typeof useFormData>;
-        $useNotification: ReturnType<typeof useNotification>;
-        $useTheme: ReturnType<typeof useTheme>;
-    }
-}
-
 export default {
     install(app: App, options?: { themes?: { [key: string]: RecursivePartial<MiTheme> } }) {
         Object.values(components).forEach((component) => {
@@ -38,15 +30,11 @@ export default {
         });
 
         // composables
-        app.config.globalProperties.$useFormData = useFormData;
         app.provide('useFormData', useFormData);
-        app.config.globalProperties.$useNotification = useNotification;
         app.provide('useNotification', useNotification);
-        app.config.globalProperties.$useTheme = useTheme;
         app.provide('useTheme', useTheme);
 
         // directives
-        app.config.globalProperties.$useOutsideClick = useOutsideClick;
         app.provide('useOutsideClick', useOutsideClick);
 
         // component


### PR DESCRIPTION
## Summary

- composables / directives の `globalProperties` 登録を削除し、`provide` のみに統一
- Vue 3 では `provide/inject` がより慣用的なアプローチで、`globalProperties` は不要
- `declare module 'vue'` の `NuxtApp` 型拡張も削除（`vue` モジュールには `NuxtApp` が存在せず無効な宣言だった）

Closes #704

## Test plan

- [ ] `pnpm type-check` がパスすること
- [ ] `pnpm build` が正常に完了すること
- [ ] プラグインインストール後、`inject('useFormData')` 等が正常に動作すること

Generated with [Claude Code](https://claude.ai/code)