### PR TITLE
perf: Pagination - computed 内の document.body.clientWidth を ResizeObserver で管理

### DIFF
--- a/src/components/navigation/Pagination.vue
+++ b/src/components/navigation/Pagination.vue
@@ -63,18 +63,18 @@ const props = withDefaults(
 );
 
 const clientWidth = ref(0);
-
-const onResize = () => {
-    clientWidth.value = window.innerWidth;
-};
+let resizeObserver: ResizeObserver | null = null;
 
 onMounted(() => {
-    clientWidth.value = window.innerWidth;
-    window.addEventListener('resize', onResize);
+    clientWidth.value = document.documentElement.clientWidth;
+    resizeObserver = new ResizeObserver((entries) => {
+        clientWidth.value = entries[0].contentRect.width;
+    });
+    resizeObserver.observe(document.documentElement);
 });
 
 onUnmounted(() => {
-    window.removeEventListener('resize', onResize);
+    resizeObserver?.disconnect();
 });
 
 const component = computed(() => {

--- a/src/components/navigation/Pagination.vue
+++ b/src/components/navigation/Pagination.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type Component, computed } from 'vue';
+import { type Component, computed, onMounted, onUnmounted, ref } from 'vue';
 import Button from '@/components/basic/Button.vue';
 import Frame from '@/components/frame/Frame.vue';
 import PictureFrame from '@/components/frame/PictureFrame.vue';
@@ -62,6 +62,21 @@ const props = withDefaults(
     }
 );
 
+const clientWidth = ref(0);
+let resizeObserver: ResizeObserver | null = null;
+
+onMounted(() => {
+    clientWidth.value = document.body.clientWidth;
+    resizeObserver = new ResizeObserver((entries) => {
+        clientWidth.value = entries[0].contentRect.width;
+    });
+    resizeObserver.observe(document.body);
+});
+
+onUnmounted(() => {
+    resizeObserver?.disconnect();
+});
+
 const component = computed(() => {
     if (props.shape === 'picture-frame') {
         return PictureFrame;
@@ -81,9 +96,7 @@ const pages = computed(() => {
         return [];
     }
 
-    const clientWidth = document.body.clientWidth;
-
-    const pagenationLimit = clientWidth > 600 ? props.pagenationLimit : props.pagenationLimitMobile;
+    const pagenationLimit = clientWidth.value > 600 ? props.pagenationLimit : props.pagenationLimitMobile;
     const PAGENATION_LIMIT_CALC = pagenationLimit / 2;
     const limitPrev = Math.max(currentPage.value - PAGENATION_LIMIT_CALC, 0);
     const limitNext = Math.min(currentPage.value + PAGENATION_LIMIT_CALC, props.total + 1);

--- a/src/components/navigation/Pagination.vue
+++ b/src/components/navigation/Pagination.vue
@@ -63,18 +63,18 @@ const props = withDefaults(
 );
 
 const clientWidth = ref(0);
-let resizeObserver: ResizeObserver | null = null;
+
+const onResize = () => {
+    clientWidth.value = window.innerWidth;
+};
 
 onMounted(() => {
-    clientWidth.value = document.body.clientWidth;
-    resizeObserver = new ResizeObserver((entries) => {
-        clientWidth.value = entries[0].contentRect.width;
-    });
-    resizeObserver.observe(document.body);
+    clientWidth.value = window.innerWidth;
+    window.addEventListener('resize', onResize);
 });
 
 onUnmounted(() => {
-    resizeObserver?.disconnect();
+    window.removeEventListener('resize', onResize);
 });
 
 const component = computed(() => {

--- a/src/stories/navigation/Pagination.stories.ts
+++ b/src/stories/navigation/Pagination.stories.ts
@@ -13,7 +13,7 @@ const meta: Meta<typeof Pagination> = {
     }),
     args: {
         modelValue: 1,
-        total: 5
+        total: 50
     },
     argTypes: {}
 };


### PR DESCRIPTION
## Summary

- `pages` computed 内の `document.body.clientWidth` 直接参照を削除
- `ResizeObserver` でビューポート幅の変化を監視し、`clientWidth` を `ref` で管理
- computed が `clientWidth.value` に依存することで、リサイズ時に自動的に再計算される

Closes #703

## Test plan

- [x] `pnpm type-check` がパスすること
- [x] ウィンドウリサイズ時にページネーション表示数が正しく切り替わること（600px境界）
- [x] コンポーネントアンマウント時に ResizeObserver が正しく disconnect されること

Generated with [Claude Code](https://claude.ai/code)