### PR TITLE
perf: useOutsideClick - モジュールレベルの Map でリスナーを単一化

### DIFF
--- a/src/directives/useOutsideClick.ts
+++ b/src/directives/useOutsideClick.ts
@@ -1,61 +1,71 @@
-import { ref, type Directive } from 'vue';
+import { type Directive } from 'vue';
 
-export default function () {
-    const callback = ref<Function>(() => {});
-    const options = ref<{
-        handler: Function;
-        isActive: boolean;
-        ignore: Element[];
-    }>({
-        handler: () => {},
-        isActive: true,
-        ignore: []
-    });
-    const onOutsideClick = (event: Event) => {
-        const isActive = options.value.isActive;
-        if (!isActive) {
+type HandlerEntry = {
+    handler: Function;
+    isActive: boolean;
+    ignore: Element[];
+};
+
+const handlerMap = new Map<Element, HandlerEntry>();
+
+const onGlobalClick = (event: Event) => {
+    handlerMap.forEach((entry) => {
+        if (!entry.isActive) {
             return;
         }
 
-        const ignore = options.value.ignore;
-        const hasIgnoreElement = ignore.length
-            ? ignore.find((ignore) => {
-                  if (typeof ignore === 'string') {
-                      const nodes = document.querySelectorAll(ignore);
+        const hasIgnoreElement = entry.ignore.length
+            ? entry.ignore.find((ignoreEl) => {
+                  if (typeof ignoreEl === 'string') {
+                      const nodes = document.querySelectorAll(ignoreEl);
                       return Array.from<Element>(nodes).find((node) =>
                           node.contains(event.target as Node)
                       );
                   } else {
-                      return ignore.contains(event.target as Node);
+                      return ignoreEl.contains(event.target as Node);
                   }
               })
             : false;
-        if (hasIgnoreElement) {
-            return;
+
+        if (!hasIgnoreElement) {
+            entry.handler(event);
         }
+    });
+};
 
-        callback.value(event);
-    };
-
-    const vOutsideClick: Directive = {
-        mounted: (_, binding) => {
-            if (typeof binding.value === 'function') {
-                callback.value = binding.value as Function;
-            } else if (typeof binding.value === 'object') {
-                callback.value = binding.value.handler as Function;
-                options.value = { ...options.value, ...binding.value };
-            }
-            window.addEventListener('click', onOutsideClick);
-        },
-        beforeUnmount: () => {
-            window.removeEventListener('click', onOutsideClick);
-        },
-        updated: (_, binding) => {
-            if (typeof binding.value === 'object') {
-                options.value = { ...options.value, ...binding.value };
+const vOutsideClick: Directive = {
+    mounted: (el, binding) => {
+        const entry: HandlerEntry = {
+            handler: () => {},
+            isActive: true,
+            ignore: []
+        };
+        if (typeof binding.value === 'function') {
+            entry.handler = binding.value;
+        } else if (typeof binding.value === 'object') {
+            Object.assign(entry, binding.value);
+        }
+        handlerMap.set(el, entry);
+        if (handlerMap.size === 1) {
+            window.addEventListener('click', onGlobalClick);
+        }
+    },
+    beforeUnmount: (el) => {
+        handlerMap.delete(el);
+        if (handlerMap.size === 0) {
+            window.removeEventListener('click', onGlobalClick);
+        }
+    },
+    updated: (el, binding) => {
+        if (typeof binding.value === 'object') {
+            const entry = handlerMap.get(el);
+            if (entry) {
+                Object.assign(entry, binding.value);
             }
         }
-    };
+    }
+};
 
+export default function () {
     return { vOutsideClick };
 }


### PR DESCRIPTION
## Summary

- マウントごとに `window.addEventListener('click', ...)` を追加する実装を廃止
- モジュールレベルの `Map<Element, HandlerEntry>` で要素とハンドラを管理
- `window` のリスナーは最初の要素登録時に1度だけ追加し、全要素アンマウント時に削除
- クリック発生時は Map を走査して各要素ごとに独立してコールバックを評価

Closes #702

## 動作イメージ

Dialog が3つ存在する場合でも `window` のリスナーは1つのみ。クリックイベント発生時に Map を全走査し、各要素の `isActive` / `ignore` 判定を経てコールバックを呼び出す。

## Test plan

- [x] `pnpm type-check` がパスすること
- [x] Dialog 単体で外側クリック時にクローズされること
- [x] Dialog が複数存在する場合、それぞれ独立して外側クリックを検知できること
- [x] `ignore` オプションが正しく機能すること

Generated with [Claude Code](https://claude.ai/code)