### PR TITLE
perf/fix/feat: NotificationItem - DOM query 排除・バリアントスタイル修正・シャドウ色追加

### DIFF
--- a/src/components/feedback/NotificationItem.vue
+++ b/src/components/feedback/NotificationItem.vue
@@ -232,6 +232,7 @@ onUnmounted(() => {
     --c-notification-item-border-color: var(--color-status-brand);
     --c-notification-item-icon-color: var(--color-status-brand);
     --color-theme-border: var(--c-notification-item-border-color);
+    --color-theme-shadow: var(--color-status-brand-alpha);
 }
 
 .secondary {
@@ -243,24 +244,28 @@ onUnmounted(() => {
     --c-notification-item-border-color: var(--color-status-info);
     --c-notification-item-icon-color: var(--color-status-info);
     --color-theme-border: var(--c-notification-item-border-color);
+    --color-theme-shadow: var(--color-status-info-alpha);
 }
 
 .success {
     --c-notification-item-border-color: var(--color-status-success);
     --c-notification-item-icon-color: var(--color-status-success);
     --color-theme-border: var(--c-notification-item-border-color);
+    --color-theme-shadow: var(--color-status-success-alpha);
 }
 
 .warning {
     --c-notification-item-border-color: var(--color-status-warning);
     --c-notification-item-icon-color: var(--color-status-warning);
     --color-theme-border: var(--c-notification-item-border-color);
+    --color-theme-shadow: var(--color-status-warning-alpha);
 }
 
 .danger {
     --c-notification-item-border-color: var(--color-status-danger);
     --c-notification-item-icon-color: var(--color-status-danger);
     --color-theme-border: var(--c-notification-item-border-color);
+    --color-theme-shadow: var(--color-status-danger-alpha);
 }
 
 /* ▲ variant ▲ */

--- a/src/components/feedback/NotificationItem.vue
+++ b/src/components/feedback/NotificationItem.vue
@@ -231,6 +231,7 @@ onUnmounted(() => {
 .primary {
     --c-notification-item-border-color: var(--color-status-brand);
     --c-notification-item-icon-color: var(--color-status-brand);
+    --color-theme-border: var(--c-notification-item-border-color);
 }
 
 .secondary {
@@ -241,21 +242,25 @@ onUnmounted(() => {
 .info {
     --c-notification-item-border-color: var(--color-status-info);
     --c-notification-item-icon-color: var(--color-status-info);
+    --color-theme-border: var(--c-notification-item-border-color);
 }
 
 .success {
     --c-notification-item-border-color: var(--color-status-success);
     --c-notification-item-icon-color: var(--color-status-success);
+    --color-theme-border: var(--c-notification-item-border-color);
 }
 
 .warning {
     --c-notification-item-border-color: var(--color-status-warning);
     --c-notification-item-icon-color: var(--color-status-warning);
+    --color-theme-border: var(--c-notification-item-border-color);
 }
 
 .danger {
     --c-notification-item-border-color: var(--color-status-danger);
     --c-notification-item-icon-color: var(--color-status-danger);
+    --color-theme-border: var(--c-notification-item-border-color);
 }
 
 /* ▲ variant ▲ */

--- a/src/components/feedback/NotificationItem.vue
+++ b/src/components/feedback/NotificationItem.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, onUnmounted, computed } from 'vue';
 import OpacityTransition from '@/components/inner-parts/OpacityTransition.vue';
 import TranslateTransition from '@/components/inner-parts/TranslateTransition.vue';
 import Frame from '@/components/frame/Frame.vue';
 import PictureFrame from '@/components/frame/PictureFrame.vue';
 import Button from '@/components/basic/Button.vue';
-import { computed } from 'vue';
 import { sleep } from '@/assets/ts';
 import {
     X as IconX,
@@ -36,7 +35,7 @@ const component = computed(() => {
 });
 
 const flg = ref(false);
-const { notifications, removeNotification } = useNotification();
+const { notifications, removeNotification, notificationHeights, setNotificationHeight } = useNotification();
 
 // 表示位置調整
 const transitionFrom = computed(() => {
@@ -51,34 +50,22 @@ const transitionFrom = computed(() => {
 const positionY = props.notification.position.split('-')[0] as 'top' | 'bottom';
 const positionX = props.notification.position.split('-')[1] as 'right' | 'left';
 const POSITION_GAP = 16;
+
+const notificationEl = ref<HTMLElement | null>(null);
+let resizeObserver: ResizeObserver | null = null;
+
 const positionStyle = computed(() => {
-    const filteredPositions = notifications.value.filter(
-        (notification) =>
-            notification.position.includes(positionY) && notification.position.includes(positionX)
+    const samePositionNotifications = notifications.value.filter(
+        (n) => n.position.includes(positionY) && n.position.includes(positionX)
     );
-    const currentPositionIndex = filteredPositions.findIndex(
-        (notification) => notification.key === props.notification.key
+    const currentIndex = samePositionNotifications.findIndex(
+        (n) => n.key === props.notification.key
     );
-    const filteredNotificationNodes = Array.from(
-        document.querySelectorAll(
-            `[data-notification-x="${positionX}"][data-notification-y="${positionY}"]`
-        )
-    ) as HTMLElement[];
-    let filteredNotificationCurrentNodeIndex = filteredNotificationNodes.findIndex(
-        (node) => node.dataset.notificationKey === props.notification.key
-    );
-    filteredNotificationCurrentNodeIndex =
-        filteredNotificationCurrentNodeIndex !== -1
-            ? filteredNotificationCurrentNodeIndex
-            : filteredNotificationNodes.length;
-    const filteredNotificationPreHeight = filteredNotificationNodes.reduce(
-        (all, node, i) =>
-            i < filteredNotificationCurrentNodeIndex
-                ? all + node.getBoundingClientRect().height
-                : all,
+    const prevHeight = samePositionNotifications.slice(0, currentIndex).reduce(
+        (sum, n) => sum + (notificationHeights.value[n.key] ?? 0),
         0
     );
-    const positionYGap = (currentPositionIndex + 1) * POSITION_GAP + filteredNotificationPreHeight;
+    const positionYGap = (currentIndex + 1) * POSITION_GAP + prevHeight;
     return `${positionY}: ${positionYGap}px; ${positionX}: ${POSITION_GAP}px`;
 });
 
@@ -109,10 +96,22 @@ const onClosed = async () => {
 onMounted(async () => {
     flg.value = true;
 
+    if (notificationEl.value) {
+        setNotificationHeight(props.notification.key, notificationEl.value.getBoundingClientRect().height);
+        resizeObserver = new ResizeObserver((entries) => {
+            setNotificationHeight(props.notification.key, entries[0].contentRect.height);
+        });
+        resizeObserver.observe(notificationEl.value);
+    }
+
     if (props.notification.autoRemove) {
         await sleep(5000);
         onClose();
     }
+});
+
+onUnmounted(() => {
+    resizeObserver?.disconnect();
 });
 </script>
 
@@ -129,9 +128,7 @@ onMounted(async () => {
             >
                 <component
                     :is="component"
-                    :data-notification-x="positionX"
-                    :data-notification-y="positionY"
-                    :data-notification-key="notification.key"
+                    ref="notificationEl"
                     v-show="flg"
                     class="notification"
                     :class="[notification.variant, notification.size]"

--- a/src/components/feedback/NotificationItem.vue
+++ b/src/components/feedback/NotificationItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed } from 'vue';
+import { ref, onMounted, onUnmounted, computed, type ComponentPublicInstance } from 'vue';
 import OpacityTransition from '@/components/inner-parts/OpacityTransition.vue';
 import TranslateTransition from '@/components/inner-parts/TranslateTransition.vue';
 import Frame from '@/components/frame/Frame.vue';
@@ -51,7 +51,7 @@ const positionY = props.notification.position.split('-')[0] as 'top' | 'bottom';
 const positionX = props.notification.position.split('-')[1] as 'right' | 'left';
 const POSITION_GAP = 16;
 
-const notificationEl = ref<HTMLElement | null>(null);
+const notificationEl = ref<ComponentPublicInstance | null>(null);
 let resizeObserver: ResizeObserver | null = null;
 
 const positionStyle = computed(() => {
@@ -96,12 +96,13 @@ const onClosed = async () => {
 onMounted(async () => {
     flg.value = true;
 
-    if (notificationEl.value) {
-        setNotificationHeight(props.notification.key, notificationEl.value.getBoundingClientRect().height);
+    const el = notificationEl.value?.$el as HTMLElement | undefined;
+    if (el) {
+        setNotificationHeight(props.notification.key, el.getBoundingClientRect().height);
         resizeObserver = new ResizeObserver((entries) => {
             setNotificationHeight(props.notification.key, entries[0].contentRect.height);
         });
-        resizeObserver.observe(notificationEl.value);
+        resizeObserver.observe(el);
     }
 
     if (props.notification.autoRemove) {

--- a/src/composables/useNotification.ts
+++ b/src/composables/useNotification.ts
@@ -52,6 +52,7 @@ export interface MiRequiredNotification extends Required<MiNotificationOption> {
 
 // global state
 const notifications = ref<MiRequiredNotification[]>([]);
+const notificationHeights = ref<Record<string, number>>({});
 
 export default function () {
     const defaultOption: MiRequiredNotification = {
@@ -80,7 +81,12 @@ export default function () {
         if (targetIndex !== -1) {
             notifications.value.splice(targetIndex, 1);
         }
+        delete notificationHeights.value[key];
     };
 
-    return { notifications, addNotification, removeNotification };
+    const setNotificationHeight = (key: string, height: number) => {
+        notificationHeights.value[key] = height;
+    };
+
+    return { notifications, addNotification, removeNotification, notificationHeights, setNotificationHeight };
 }

--- a/src/stories/feedback/Notifications.stories.ts
+++ b/src/stories/feedback/Notifications.stories.ts
@@ -3,7 +3,7 @@ import Button from '@/components/basic/Button.vue';
 import type { Args, Meta, StoryObj } from '@storybook/vue3';
 import useNotification, { type MiNotificationOption } from '@/composables/useNotification';
 
-const meta: Meta<typeof Notifications> = {
+const meta: Meta<MiNotificationOption> = {
     component: Notifications,
     render: (args: Args) => ({
         components: { Notifications, Button },
@@ -12,10 +12,8 @@ const meta: Meta<typeof Notifications> = {
             return {
                 args,
                 onSetNotification: () => {
-                    addNotification({
-                        title: '通知',
-                        message: 'テスト通知'
-                    });
+                    const { variant, size, shape, position, noShadow, title, message, closeable, autoRemove } = args;
+                    addNotification({ variant, size, shape, position, noShadow, title, message, closeable, autoRemove });
                 }
             };
         },
@@ -23,12 +21,55 @@ const meta: Meta<typeof Notifications> = {
 <Button @click="onSetNotification">Open Notifications</Button>
 <Notifications />`
     }),
-    args: {},
+    args: {
+        variant: 'secondary',
+        size: 'medium',
+        shape: 'normal',
+        position: 'top-right',
+        noShadow: false,
+        title: '通知',
+        message: 'テスト通知',
+        closeable: false,
+        autoRemove: true
+    },
+    argTypes: {
+        variant: {
+            control: 'select',
+            options: ['primary', 'secondary', 'info', 'success', 'warning', 'danger']
+        },
+        size: {
+            control: 'select',
+            options: ['small', 'medium', 'large']
+        },
+        shape: {
+            control: 'select',
+            options: ['normal', 'no-radius', 'picture-frame']
+        },
+        position: {
+            control: 'select',
+            options: ['top-right', 'top-left', 'bottom-right', 'bottom-left']
+        },
+        noShadow: {
+            control: 'boolean'
+        },
+        title: {
+            control: 'text'
+        },
+        message: {
+            control: 'text'
+        },
+        closeable: {
+            control: 'boolean'
+        },
+        autoRemove: {
+            control: 'boolean'
+        }
+    },
     tags: ['autodocs']
 };
 
 export default meta;
-type Story = StoryObj<typeof Notifications>;
+type Story = StoryObj<MiNotificationOption>;
 
 export const Default: Story = {};
 


### PR DESCRIPTION
## Summary

- `positionStyle` computed 内の `document.querySelectorAll()` と `getBoundingClientRect()` を排除
  - `useNotification` に `notificationHeights` / `setNotificationHeight` を追加
  - 各 NotificationItem が `onMounted` + `ResizeObserver` で自身の高さを計測・報告
  - `positionStyle` は `notificationHeights`（reactive ref）のみを参照するよう変更
- `ref` をコンポーネントに付けた際に `$el` 経由で実 DOM 要素を取得するよう修正（`getBoundingClientRect` エラー解消）
- Frame 導入時に切れた variant → border-color の接続を復元
  - 各バリアントクラスで `--color-theme-border` をローカル上書きし Frame の `::after` にカスケード
- バリアントに応じた半透明シャドウ色を追加（`--color-status-*-alpha` を使用）

Closes #701

## Test plan

- [x] `pnpm type-check` がパスすること
- [x] 通知が複数同時表示されたとき、重ならず縦に並ぶこと
- [x] 通知が追加/削除されたとき、残りの通知の位置が正しく再計算されること
- [x] バリアントごとにボーダー色・シャドウ色が正しく表示されること（primary / info / success / warning / danger）
- [x] secondary はデフォルトのテーマカラーのまま表示されること

Generated with [Claude Code](https://claude.ai/code)