### PR TITLE
perf: Autocomplete - matchItems の変換キャッシュ化と debounce 導入

### DIFF
--- a/src/components/controls/Autocomplete.vue
+++ b/src/components/controls/Autocomplete.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch, ref } from 'vue';
+import { computed, watch, ref, onUnmounted } from 'vue';
 import { useField } from 'vee-validate';
 import { ZodString } from 'zod';
 import FieldFrame from '@/components/inner-parts/FieldFrame.vue';
@@ -132,8 +132,15 @@ const max = computed(
         )?.value || null
 );
 
+const debouncedSearchValue = ref('');
+let debounceTimer: ReturnType<typeof setTimeout>;
+
 watch(value, (v) => {
     model.value = v;
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+        debouncedSearchValue.value = v ?? '';
+    }, 150);
 });
 
 // NOTE: 曖昧一致により、nullとundefinedを判定し、0は判定外とする
@@ -141,66 +148,75 @@ if (value.value == null && model.value != null) {
     value.value = model.value;
 }
 
+debouncedSearchValue.value = value.value ?? '';
+
+onUnmounted(() => clearTimeout(debounceTimer));
+
 const inputRef = ref();
 const isFocus = ref(false);
 
+// items 変更時のみ変換処理を実行し、キーストローク毎の再計算を回避する
+const formattedItemsCache = computed(() =>
+    props.items.map((item) => {
+        const val = item.value.toString();
+        const ruby = item.ruby;
+        return {
+            item,
+            variants: Array.from(
+                new Set([
+                    hira2Kata(item.label),
+                    kata2Hira(item.label),
+                    kanaHalf2Full(hira2Kata(item.label)),
+                    kataFull2Half(hira2Kata(item.label)),
+                    alphanumericFull2Half(item.label),
+                    alphanumericHalf2Full(item.label),
+                    hira2Kata(val),
+                    kata2Hira(val),
+                    kanaHalf2Full(hira2Kata(val)),
+                    kataFull2Half(hira2Kata(val)),
+                    alphanumericFull2Half(val),
+                    alphanumericHalf2Full(val),
+                    ...(ruby
+                        ? [
+                              hira2Kata(ruby),
+                              kata2Hira(ruby),
+                              kanaHalf2Full(hira2Kata(ruby)),
+                              kataFull2Half(hira2Kata(ruby)),
+                              alphanumericFull2Half(ruby),
+                              alphanumericHalf2Full(ruby)
+                          ]
+                        : [])
+                ])
+            )
+        };
+    })
+);
+
 const matchItems = computed(() => {
-    if (!value.value) {
+    if (!debouncedSearchValue.value) {
         return props.items;
     }
-    return props.items.filter((item) => {
-        if (
-            item.label.includes(value.value) ||
-            item.value.toString().includes(value.value) ||
-            item.ruby?.includes(value.value)
-        ) {
-            // 通常チェック
-            return true;
-        }
+    const searchLower = debouncedSearchValue.value.toLocaleLowerCase();
+    return formattedItemsCache.value
+        .filter(({ item, variants }) => {
+            if (
+                item.label.includes(debouncedSearchValue.value) ||
+                item.value.toString().includes(debouncedSearchValue.value) ||
+                item.ruby?.includes(debouncedSearchValue.value)
+            ) {
+                return true;
+            }
 
-        // TODO: 処理コスト高そう……
-        const formatStrs = Array.from(
-            new Set([
-                hira2Kata(item.label),
-                kata2Hira(item.label),
-                kanaHalf2Full(hira2Kata(item.label)),
-                kataFull2Half(hira2Kata(item.label)),
-                alphanumericFull2Half(item.label),
-                alphanumericHalf2Full(item.label),
-                hira2Kata(item.value.toString()),
-                kata2Hira(item.value.toString()),
-                kanaHalf2Full(hira2Kata(item.value.toString())),
-                kataFull2Half(hira2Kata(item.value.toString())),
-                alphanumericFull2Half(item.value.toString()),
-                alphanumericHalf2Full(item.value.toString()),
-                ...(item.ruby
-                    ? [
-                          hira2Kata(item.ruby),
-                          kata2Hira(item.ruby),
-                          kanaHalf2Full(hira2Kata(item.ruby)),
-                          kataFull2Half(hira2Kata(item.ruby)),
-                          alphanumericFull2Half(item.ruby),
-                          alphanumericHalf2Full(item.ruby)
-                      ]
-                    : [])
-            ])
-        );
+            if (variants.some((str) => str.toLocaleLowerCase().includes(searchLower))) {
+                return true;
+            }
 
-        if (
-            formatStrs.findIndex((str) =>
-                str.toLocaleLowerCase().includes(value.value.toLocaleLowerCase())
-            ) !== -1
-        ) {
-            // 各種変換した文字でチェック
-            return true;
-        }
-
-        if (typeof props.match == 'function') {
-            // props.match関数チェック
-            return props.match(item, value.value);
-        }
-        return false;
-    });
+            if (typeof props.match === 'function') {
+                return props.match(item, debouncedSearchValue.value);
+            }
+            return false;
+        })
+        .map(({ item }) => item);
 });
 
 // NOTE: 初期値がリスト外の場合は初期化する


### PR DESCRIPTION
## Summary

- `formattedItemsCache` computed を追加し、`props.items` 変更時のみ6種の文字変換（ひら↔カタ、半角↔全角等）を実行。キーストローク毎にO(N×6変換)が走っていた問題を解消
- `debouncedSearchValue`（150ms debounce）を導入し、`matchItems` が高速タイピング中の中間状態で再計算されるのをスキップ
- `onUnmounted` でタイマーをクリアしメモリリークを防止

closes #699

## Test plan

- [x] テキスト入力で候補リストが正しくフィルタリングされることを確認
- [x] ひらがな・カタカナ・半角・全角の曖昧一致が機能することを確認
- [x] `ruby` フィールドによる検索が機能することを確認
- [x] `match` prop のカスタム関数が正しく呼ばれることを確認
- [x] 初期値がリスト外の場合に空文字にリセットされることを確認

Generated with [Claude Code](https://claude.ai/code)