### PR TITLE
perf: shallowRef / markRaw でリアクティビティオーバーヘッド削減

### DIFF
--- a/src/components/basic/Avatar.vue
+++ b/src/components/basic/Avatar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type Component, useSlots, computed } from 'vue';
+import { type Component, useSlots, computed, markRaw } from 'vue';
 import { User as IconUser } from 'lucide-vue-next';
 
 const props = withDefaults(
@@ -35,6 +35,7 @@ const props = withDefaults(
 );
 
 const color = computed(() => props.color);
+const rawIcon = computed(() => (props.icon ? markRaw(props.icon as Component) : undefined));
 
 const slots = useSlots();
 const hasSlot = (name: string) => {
@@ -45,7 +46,7 @@ const hasSlot = (name: string) => {
 <template>
     <img v-if="image" :src="image" class="component-avatar" :class="[size, shape]" />
     <div v-else class="component-avatar" :class="[size, shape]">
-        <component v-if="icon" :is="icon" class="icon" />
+        <component v-if="rawIcon" :is="rawIcon" class="icon" />
         <slot v-else-if="hasSlot('default')" />
         <IconUser v-else class="icon" />
     </div>

--- a/src/components/feedback/Alert.vue
+++ b/src/components/feedback/Alert.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, type Component } from 'vue';
+import { ref, computed, markRaw, type Component } from 'vue';
 import OpacityTransition from '@/components/inner-parts/OpacityTransition.vue';
 import Button from '@/components/basic/Button.vue';
 import {
@@ -9,11 +9,10 @@ import {
     AlertTriangle as IconAlertTriangle,
     XOctagon as IconXOctagon
 } from 'lucide-vue-next';
-import { computed } from 'vue';
 import { sleep } from '@/assets/ts';
 
 const flg = defineModel<boolean>({ default: true });
-withDefaults(
+const props = withDefaults(
     defineProps<{
         /**
          * 表示色
@@ -53,6 +52,8 @@ const emit = defineEmits<{
     closed: [];
 }>();
 
+const rawIcon = computed(() => (props.icon ? markRaw(props.icon as Component) : undefined));
+
 // transition状態
 const transitioning = ref(false);
 const isShowing = computed(() => {
@@ -83,7 +84,7 @@ const onClosed = async () => {
         @transition-end="transitioning = false"
     >
         <div class="component-alert" :class="[variant, shape]" v-show="flg">
-            <icon v-if="icon" class="icon" />
+            <component v-if="rawIcon" :is="rawIcon" class="icon" />
             <IconInfo v-else-if="variant === 'info'" class="icon" />
             <IconCheckCircle2 v-else-if="variant === 'success'" class="icon" />
             <IconAlertTriangle v-else-if="variant === 'warning'" class="icon" />

--- a/src/components/feedback/Dialog.vue
+++ b/src/components/feedback/Dialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, useSlots, watch, type Component } from 'vue';
+import { ref, useSlots, watch, markRaw, type Component } from 'vue';
 import OpacityTransition from '@/components/inner-parts/OpacityTransition.vue';
 import TranslateTransition from '@/components/inner-parts/TranslateTransition.vue';
 import { computed } from 'vue';
@@ -83,8 +83,9 @@ const emit = defineEmits<{
 }>();
 
 // transition状態
-const TransitionComponent =
-    props.transitionFrom === 'opacity' ? OpacityTransition : TranslateTransition;
+const TransitionComponent = markRaw(
+    props.transitionFrom === 'opacity' ? OpacityTransition : TranslateTransition
+);
 const transitioning = ref(false);
 const isShowing = computed(() => {
     if (flg.value) {

--- a/src/components/feedback/Modal.vue
+++ b/src/components/feedback/Modal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, type Component } from 'vue';
+import { ref, watch, markRaw, type Component } from 'vue';
 import OpacityTransition from '@/components/inner-parts/OpacityTransition.vue';
 import TranslateTransition from '@/components/inner-parts/TranslateTransition.vue';
 import Button from '@/components/basic/Button.vue';
@@ -69,8 +69,9 @@ const emit = defineEmits<{
 }>();
 
 // transition状態
-const TransitionComponent =
-    props.transitionFrom === 'opacity' ? OpacityTransition : TranslateTransition;
+const TransitionComponent = markRaw(
+    props.transitionFrom === 'opacity' ? OpacityTransition : TranslateTransition
+);
 const transitioning = ref(false);
 const isShowing = computed(() => {
     if (flg.value) {

--- a/src/components/navigation/Step.vue
+++ b/src/components/navigation/Step.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type Component, ref, computed, useSlots } from 'vue';
+import { type Component, ref, computed, useSlots, markRaw } from 'vue';
 import OpacityTransition from '@/components/inner-parts/OpacityTransition.vue';
 import TranslateTransition from '@/components/inner-parts/TranslateTransition.vue';
 import Button from '@/components/basic/Button.vue';
@@ -45,8 +45,9 @@ const emit = defineEmits<{
 }>();
 
 // transition状態
-const TransitionComponent =
-    props.transition === 'opacity' ? OpacityTransition : TranslateTransition;
+const TransitionComponent = markRaw(
+    props.transition === 'opacity' ? OpacityTransition : TranslateTransition
+);
 const transitionFrom = ref('right');
 
 const onChangeTab = (id: string) => {

--- a/src/components/navigation/Tab.vue
+++ b/src/components/navigation/Tab.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type Component, ref, computed } from 'vue';
+import { type Component, ref, computed, markRaw } from 'vue';
 import OpacityTransition from '@/components/inner-parts/OpacityTransition.vue';
 import TranslateTransition from '@/components/inner-parts/TranslateTransition.vue';
 import Button from '@/components/basic/Button.vue';
@@ -56,8 +56,9 @@ const tabAlignProperty = computed(() => {
 });
 
 // transition状態
-const TransitionComponent =
-    props.transition === 'opacity' ? OpacityTransition : TranslateTransition;
+const TransitionComponent = markRaw(
+    props.transition === 'opacity' ? OpacityTransition : TranslateTransition
+);
 const transitionFrom = ref('right');
 
 const tabHeaderRef = ref();

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -5,7 +5,7 @@
  * ==================================================
  */
 
-import { ref, watch } from 'vue';
+import { ref, shallowRef, watch } from 'vue';
 import { useHead } from '@unhead/vue';
 import { toKebabCase } from '@/assets/ts/formatter';
 import merge from 'lodash.merge';
@@ -103,7 +103,7 @@ const baseTheme: MiTheme = {
         danger: '--color-base-red'
     }
 } as const;
-const themes = ref<{ [key: string]: RecursivePartial<MiTheme> }>({
+const themes = shallowRef<{ [key: string]: RecursivePartial<MiTheme> }>({
     light: {
         theme: {
             textPrimary: '--color-base-black',


### PR DESCRIPTION
## Summary

- `useTheme.ts`: `themes` を `ref` → `shallowRef` に変更。`overrideTheme` は `themes.value` を丸ごと置き換えるだけなので深い追跡は不要
- `Dialog.vue` / `Modal.vue` / `Tab.vue` / `Step.vue`: `TransitionComponent` を `markRaw()` でラップし、Vue のリアクティブシステムがコンポーネントオブジェクトをプロキシしないよう明示
- `Avatar.vue` / `Alert.vue`: `icon` prop を computed 内で `markRaw()` 処理。props 経由でリアクティブプロキシになったコンポーネントオブジェクトの不要なトラッキングを回避

closes #705

## Test plan

- [x] テーマ切り替え（light/dark）が正常に動作することを確認
- [x] Dialog / Modal の transition アニメーションが正常に動作することを確認
- [x] Tab / Step のタブ切り替えアニメーションが正常に動作することを確認
- [x] Avatar の icon prop が正しくレンダリングされることを確認
- [x] Alert の icon prop が正しくレンダリングされることを確認

Generated with [Claude Code](https://claude.ai/code)