### PR TITLE
chore(ci): create-release-pr ワークフローの bundle 実行エラーを修正

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -18,7 +18,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -27,10 +27,11 @@ jobs:
         uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
         with:
           ruby-version: 3.1
-          gemfile: .github/Gemfile
+          working-directory: .github
           bundler-cache: true
       - name: Create a release pull request
         env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/.github/Gemfile
           GIT_PR_RELEASE_TOKEN: ${{ steps.generate_token.outputs.token }}
           GIT_PR_RELEASE_BRANCH_PRODUCTION: main
           GIT_PR_RELEASE_BRANCH_STAGING: develop


### PR DESCRIPTION
## Summary

- `setup-ruby` の非サポートパラメータ `gemfile` を `working-directory: .github` に変更（v1.308.0 では `gemfile` は無効なパラメータのため `bundle install` がスキップされていた）
- `bundle exec` 実行時に Gemfile を参照できるよう `BUNDLE_GEMFILE` 環境変数を追加（`run` ステップはリポジトリルートで動くため必要）
- deprecated な `app-id` を `client-id` に変更

## Background

前回の CI 改善 PR でワークフローを変更した際、以下のエラーが発生してリリース PR のチェックリストが更新されなくなっていた：

```
##[warning]Unexpected input(s) 'gemfile', valid inputs are [..., 'working-directory', ...]
Could not determine gemfile path, skipping "bundle install" and caching
Could not locate Gemfile or .bundle/ directory
Done.
```

`|| echo "Done."` によってエラーが隠れ、アクション自体は正常終了しているように見えていた。

## Test plan

- [ ] develop への push 後に create-release-pr ワークフローが正常に動作し、リリース PR のチェックリストが更新されることを確認

Generated with [Claude Code](https://claude.ai/code)