### PR TITLE
fix(controls): touched 前にバリデーションエラーが即表示される問題を修正

### DIFF
--- a/src/components/controls/Checkbox.vue
+++ b/src/components/controls/Checkbox.vue
@@ -71,7 +71,9 @@ const {
     value: fieldVal,
     checked,
     errors,
-    handleChange
+    handleChange,
+    setTouched,
+    meta
 } = useField<string | number | boolean>(fieldName, undefined, {
     type: 'checkbox',
     checkedValue: props.value,
@@ -95,6 +97,7 @@ const onChange = (event: Event) => {
     if (!(event.target as HTMLInputElement).checked) {
         val = unCheckValue.value;
     }
+    setTouched(true);
     handleChange(val);
 };
 
@@ -132,7 +135,7 @@ if (fieldVal.value == null && model.value != null) {
                 </div>
             </label>
         </div>
-        <template v-if="isErrorMessage">
+        <template v-if="isErrorMessage && meta.touched">
             <div v-for="error in errors" :key="error" class="error">{{ error }}</div>
         </template>
     </div>

--- a/src/components/controls/Radio.vue
+++ b/src/components/controls/Radio.vue
@@ -73,7 +73,9 @@ const {
     value: fieldVal,
     checked,
     errors,
-    handleChange
+    handleChange,
+    setTouched,
+    meta
 } = useField<string | number | boolean>(fieldName, undefined, {
     type: 'radio',
     checkedValue: props.value,
@@ -88,6 +90,7 @@ const isRequired = computed(
 );
 
 const onChange = (event: Event) => {
+    setTouched(true);
     if (!(event.target as HTMLInputElement).checked) {
         fieldVal.value = unCheckValue.value;
     } else {
@@ -129,7 +132,7 @@ if (fieldVal.value == null && model.value != null) {
                 </div>
             </label>
         </div>
-        <template v-if="isErrorMessage">
+        <template v-if="isErrorMessage && meta.touched">
             <div v-for="error in errors" :key="error" class="error">{{ error }}</div>
         </template>
     </div>

--- a/src/components/controls/Switch.vue
+++ b/src/components/controls/Switch.vue
@@ -62,7 +62,9 @@ const {
     value: fieldVal,
     checked,
     errors,
-    handleChange
+    handleChange,
+    setTouched,
+    meta
 } = useField<boolean>(fieldName, undefined, {
     type: 'checkbox',
     checkedValue: props.value,
@@ -79,6 +81,7 @@ const onChange = (event: Event) => {
     if (!(event.target as HTMLInputElement).checked) {
         val = false;
     }
+    setTouched(true);
     handleChange(val);
 };
 
@@ -124,7 +127,7 @@ if (fieldVal.value == null && model.value != null) {
                 </div>
             </label>
         </div>
-        <template v-if="isErrorMessage">
+        <template v-if="isErrorMessage && meta.touched">
             <div v-for="error in errors" :key="error" class="error">{{ error }}</div>
         </template>
     </div>

--- a/src/test/components/controls/Checkbox.spec.ts
+++ b/src/test/components/controls/Checkbox.spec.ts
@@ -86,12 +86,13 @@ describe('Checkbox', () => {
         expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['']);
     });
 
-    it('フォームコンテキストからエラーが設定されると error div がレンダリングされる', async () => {
+    it('フォームコンテキストで touched かつエラーが設定されると error div がレンダリングされる', async () => {
         const fieldName = uniqueFieldName('checkbox-err');
         const TestParent = defineComponent({
             setup() {
-                const { setFieldError } = useForm();
+                const { setFieldError, setFieldTouched } = useForm();
                 onMounted(() => {
+                    setFieldTouched(fieldName, true);
                     setFieldError(fieldName, 'エラーメッセージ');
                 });
                 return () => h(Checkbox, { name: fieldName });
@@ -99,6 +100,43 @@ describe('Checkbox', () => {
         });
         const wrapper = mount(TestParent);
         await nextTick();
+        await nextTick();
+        expect(wrapper.find('.error').exists()).toBe(true);
+    });
+
+    it('literal(true) schema + initialValues 未指定でマウント直後はエラーが表示されない', () => {
+        const schema = z.literal(true);
+        const fieldName = uniqueFieldName('checkbox-no-err');
+        const TestParent = defineComponent({
+            setup() {
+                useForm();
+                return () => h(Checkbox, { name: fieldName, schema });
+            }
+        });
+        const wrapper = mount(TestParent);
+        expect(wrapper.find('.error').exists()).toBe(false);
+    });
+
+    it('エラーあり・未操作（not touched）ではエラーが表示されず、change 後（touched）に表示される', async () => {
+        const schema = z.literal(true);
+        const fieldName = uniqueFieldName('checkbox-touched-err');
+        const TestParent = defineComponent({
+            setup() {
+                const { setFieldError } = useForm();
+                onMounted(() => {
+                    // バリデーション済みエラーがある状態を再現
+                    setFieldError(fieldName, 'チェックしてください。');
+                });
+                return () => h(Checkbox, { name: fieldName, schema });
+            }
+        });
+        const wrapper = mount(TestParent);
+        await nextTick();
+        await nextTick();
+        // touched 前はエラーを表示しない
+        expect(wrapper.find('.error').exists()).toBe(false);
+        // ユーザーが操作（change → setTouched(true)）するとエラーが表示される
+        await wrapper.find('input[type="checkbox"]').trigger('change');
         await nextTick();
         expect(wrapper.find('.error').exists()).toBe(true);
     });

--- a/src/test/components/controls/Radio.spec.ts
+++ b/src/test/components/controls/Radio.spec.ts
@@ -74,12 +74,13 @@ describe('Radio', () => {
         expect(wrapper.emitted('update:modelValue')).toBeTruthy();
     });
 
-    it('フォームコンテキストからエラーが設定されると error div がレンダリングされる', async () => {
+    it('フォームコンテキストで touched かつエラーが設定されると error div がレンダリングされる', async () => {
         const fieldName = uniqueFieldName('radio-err');
         const TestParent = defineComponent({
             setup() {
-                const { setFieldError } = useForm();
+                const { setFieldError, setFieldTouched } = useForm();
                 onMounted(() => {
+                    setFieldTouched(fieldName, true);
                     setFieldError(fieldName, 'エラーメッセージ');
                 });
                 return () => h(Radio, { name: fieldName });
@@ -87,6 +88,42 @@ describe('Radio', () => {
         });
         const wrapper = mount(TestParent);
         await nextTick();
+        await nextTick();
+        expect(wrapper.find('.error').exists()).toBe(true);
+    });
+
+    it('schema + initialValues 未指定でマウント直後はエラーが表示されない', () => {
+        const schema = z.string().min(1);
+        const fieldName = uniqueFieldName('radio-no-err');
+        const TestParent = defineComponent({
+            setup() {
+                useForm();
+                return () => h(Radio, { name: fieldName, schema, value: 'apple' });
+            }
+        });
+        const wrapper = mount(TestParent);
+        expect(wrapper.find('.error').exists()).toBe(false);
+    });
+
+    it('エラーあり・未操作（not touched）ではエラーが表示されず、change 後（touched）に表示される', async () => {
+        const schema = z.string().min(1);
+        const fieldName = uniqueFieldName('radio-touched-err');
+        const TestParent = defineComponent({
+            setup() {
+                const { setFieldError } = useForm();
+                onMounted(() => {
+                    setFieldError(fieldName, '選択してください。');
+                });
+                return () => h(Radio, { name: fieldName, schema, value: 'apple' });
+            }
+        });
+        const wrapper = mount(TestParent);
+        await nextTick();
+        await nextTick();
+        expect(wrapper.find('.error').exists()).toBe(false);
+        const input = wrapper.find('input[type="radio"]');
+        (input.element as HTMLInputElement).checked = true;
+        await input.trigger('change');
         await nextTick();
         expect(wrapper.find('.error').exists()).toBe(true);
     });

--- a/src/test/components/controls/Switch.spec.ts
+++ b/src/test/components/controls/Switch.spec.ts
@@ -79,12 +79,13 @@ describe('Switch', () => {
         expect(wrapper.emitted('update:modelValue')).toBeTruthy();
     });
 
-    it('フォームコンテキストからエラーが設定されると error div がレンダリングされる', async () => {
+    it('フォームコンテキストで touched かつエラーが設定されると error div がレンダリングされる', async () => {
         const fieldName = uniqueFieldName('switch-err');
         const TestParent = defineComponent({
             setup() {
-                const { setFieldError } = useForm();
+                const { setFieldError, setFieldTouched } = useForm();
                 onMounted(() => {
+                    setFieldTouched(fieldName, true);
                     setFieldError(fieldName, 'エラーメッセージ');
                 });
                 return () => h(Switch, { name: fieldName });
@@ -92,6 +93,40 @@ describe('Switch', () => {
         });
         const wrapper = mount(TestParent);
         await nextTick();
+        await nextTick();
+        expect(wrapper.find('.error').exists()).toBe(true);
+    });
+
+    it('literal(true) schema + initialValues 未指定でマウント直後はエラーが表示されない', () => {
+        const schema = z.literal(true);
+        const fieldName = uniqueFieldName('switch-no-err');
+        const TestParent = defineComponent({
+            setup() {
+                useForm();
+                return () => h(Switch, { name: fieldName, schema });
+            }
+        });
+        const wrapper = mount(TestParent);
+        expect(wrapper.find('.error').exists()).toBe(false);
+    });
+
+    it('エラーあり・未操作（not touched）ではエラーが表示されず、change 後（touched）に表示される', async () => {
+        const schema = z.literal(true);
+        const fieldName = uniqueFieldName('switch-touched-err');
+        const TestParent = defineComponent({
+            setup() {
+                const { setFieldError } = useForm();
+                onMounted(() => {
+                    setFieldError(fieldName, 'ONにしてください。');
+                });
+                return () => h(Switch, { name: fieldName, schema });
+            }
+        });
+        const wrapper = mount(TestParent);
+        await nextTick();
+        await nextTick();
+        expect(wrapper.find('.error').exists()).toBe(false);
+        await wrapper.find('input[type="checkbox"]').trigger('change');
         await nextTick();
         expect(wrapper.find('.error').exists()).toBe(true);
     });


### PR DESCRIPTION
## Summary

- `MiCheckbox` / `MiRadio` / `MiSwitch` で `name` + `schema` を指定した場合、ユーザーが未操作の状態でもマウント直後にエラーが表示されていた問題を修正
- `onChange` 内で `setTouched(true)` を呼び出し、エラー表示を `meta.touched` でガード
- vee-validate は送信時に全フィールドを `touched` にするため、フォーム送信後のエラー表示は維持される

## Root Cause

`useField` の `type: 'checkbox'` / `type: 'radio'` オプションがマウント時に `uncheckedValue` で値を強制初期化し、`validateOnValueUpdate` が発火することでエラーが積まれていた。

## Changes

| ファイル | 変更内容 |
|---|---|
| `Checkbox.vue` | `setTouched` / `meta` を追加、`onChange` で `setTouched(true)` 呼び出し、エラー表示を `meta.touched` でガード |
| `Radio.vue` | 同上 |
| `Switch.vue` | 同上 |
| `Checkbox.spec.ts` | 既存テスト修正（`setFieldTouched` 追加）、回帰テスト 2 件追加 |
| `Radio.spec.ts` | 同上 |
| `Switch.spec.ts` | 同上 |

## Scope

`Select` / `RadioGroup` / `CheckboxGroup` は `useField` に `type` オプションを指定していないため、本問題は発生しない（対応不要）。

## Test plan

- [x] `pnpm test:run` — 全 591 テスト green を確認
- [x] `pnpm test:coverage` — `Checkbox.vue` / `Radio.vue` / `Switch.vue` のカバレッジ 100% を確認
- [x] マウント直後にエラーが表示されないこと（回帰テストで担保）
- [x] フォーム送信後にエラーが表示されること（vee-validate の全フィールド touched 動作で担保）

closes #759

Generated with [Claude Code](https://claude.ai/code)