### PR TITLE
refactor(controls): useCheckableField コンポーザブルに touched パターンを集約

### DIFF
--- a/src/components/controls/Checkbox.vue
+++ b/src/components/controls/Checkbox.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type Ref, computed, useId, watch } from 'vue';
-import { useField } from 'vee-validate';
 import { ZodNumber, ZodString, ZodNullable, ZodBoolean, ZodLiteral } from 'zod';
+import { useCheckableField } from '@/composables/useCheckableField';
 import { CheckSquare as IconCheckSquare, Square as IconSquare } from 'lucide-vue-next';
 
 const model = defineModel<string | number | boolean>();
@@ -67,18 +67,8 @@ const unCheckValue = computed(() => (typeof props.value === 'boolean' ? false : 
 
 const generatedId = useId();
 const fieldName = computed(() => props.name || generatedId);
-const {
-    value: fieldVal,
-    checked,
-    errors,
-    handleChange,
-    setTouched,
-    meta
-} = useField<string | number | boolean>(fieldName, undefined, {
-    type: 'checkbox',
-    checkedValue: props.value,
-    uncheckedValue: unCheckValue.value
-});
+const { value: fieldVal, checked, errors, meta, onFieldChange } =
+    useCheckableField<string | number | boolean>(fieldName, 'checkbox', props.value, unCheckValue.value);
 
 const schemaChunks = computed(() => (props.schema as ZodString | undefined)?._def.checks);
 const isRequired = computed(() => {
@@ -93,12 +83,10 @@ const isRequired = computed(() => {
 
 const onChange = (event: Event) => {
     let val = (event.target as HTMLInputElement).value as string | number | boolean;
-
     if (!(event.target as HTMLInputElement).checked) {
         val = unCheckValue.value;
     }
-    setTouched(true);
-    handleChange(val);
+    onFieldChange(val);
 };
 
 watch(checked as Ref<boolean>, (flg) => {

--- a/src/components/controls/Radio.vue
+++ b/src/components/controls/Radio.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type Ref, computed, useId, watch } from 'vue';
-import { useField } from 'vee-validate';
 import { ZodNumber, ZodString, ZodNullable, ZodBoolean, ZodLiteral } from 'zod';
+import { useCheckableField } from '@/composables/useCheckableField';
 import { CircleCheck as IconCircleCheck, Circle as IconCircle } from 'lucide-vue-next';
 
 // TODO: ラジオボタンのチェック済みアイコンが適切ではないが、lucideにはまだないため、仮置き
@@ -69,18 +69,8 @@ const unCheckValue = computed(() => (typeof props.value === 'boolean' ? false : 
 
 const generatedId = useId();
 const fieldName = computed(() => props.name || generatedId);
-const {
-    value: fieldVal,
-    checked,
-    errors,
-    handleChange,
-    setTouched,
-    meta
-} = useField<string | number | boolean>(fieldName, undefined, {
-    type: 'radio',
-    checkedValue: props.value,
-    uncheckedValue: unCheckValue.value
-});
+const { value: fieldVal, checked, errors, meta, onFieldChange, setTouched } =
+    useCheckableField<string | number | boolean>(fieldName, 'radio', props.value, unCheckValue.value);
 
 const schemaChunks = computed(() => (props.schema as ZodString | undefined)?._def.checks);
 const isRequired = computed(
@@ -90,11 +80,11 @@ const isRequired = computed(
 );
 
 const onChange = (event: Event) => {
-    setTouched(true);
     if (!(event.target as HTMLInputElement).checked) {
+        setTouched(true);
         fieldVal.value = unCheckValue.value;
     } else {
-        handleChange(event as unknown as string | number | boolean);
+        onFieldChange(event as unknown as string | number | boolean);
     }
 };
 

--- a/src/components/controls/Switch.vue
+++ b/src/components/controls/Switch.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type Ref, computed, useId, watch } from 'vue';
-import { useField } from 'vee-validate';
 import { ZodNullable, ZodBoolean, ZodLiteral } from 'zod';
+import { useCheckableField } from '@/composables/useCheckableField';
 
 const model = defineModel<boolean>();
 const props = withDefaults(
@@ -58,31 +58,17 @@ const props = withDefaults(
 
 const generatedId = useId();
 const fieldName = computed(() => props.name || generatedId);
-const {
-    value: fieldVal,
-    checked,
-    errors,
-    handleChange,
-    setTouched,
-    meta
-} = useField<boolean>(fieldName, undefined, {
-    type: 'checkbox',
-    checkedValue: props.value,
-    uncheckedValue: false
-});
+const { value: fieldVal, checked, errors, meta, onFieldChange } =
+    useCheckableField<boolean>(fieldName, 'checkbox', props.value, false);
 
 const isRequired = computed(() =>
     props.schema ? props.schema?._def.typeName === 'ZodLiteral' : props.required
 );
 
 const onChange = (event: Event) => {
-    let val = JSON.parse((event.target as HTMLInputElement).value.toLowerCase());
-
-    if (!(event.target as HTMLInputElement).checked) {
-        val = false;
-    }
-    setTouched(true);
-    handleChange(val);
+    const input = event.target as HTMLInputElement;
+    const val = input.checked ? (JSON.parse(input.value.toLowerCase()) as boolean) : false;
+    onFieldChange(val);
 };
 
 watch(checked as Ref<boolean>, (flg) => {

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,4 +1,6 @@
 // 自動生成ファイル。直接編集禁止。pnpm create-component-d で再生成
+export { default as useCheckableField } from './useCheckableField';
+export * from './useCheckableField';
 export { default as useFormData } from './useFormData';
 export * from './useFormData';
 export { default as useNotification } from './useNotification';

--- a/src/composables/useCheckableField.ts
+++ b/src/composables/useCheckableField.ts
@@ -1,0 +1,21 @@
+import type { MaybeRefOrGetter } from 'vue';
+import { useField } from 'vee-validate';
+
+export function useCheckableField<T>(
+    fieldName: MaybeRefOrGetter<string>,
+    type: 'checkbox' | 'radio',
+    checkedValue: T,
+    uncheckedValue: T
+) {
+    const { value, checked, errors, handleChange, setTouched, meta } =
+        useField<T>(fieldName, undefined, { type, checkedValue, uncheckedValue });
+
+    const onFieldChange = (val: unknown) => {
+        setTouched(true);
+        handleChange(val);
+    };
+
+    return { value, checked, errors, meta, onFieldChange, setTouched };
+}
+
+export default useCheckableField;

--- a/src/nuxt/composable-map.ts
+++ b/src/nuxt/composable-map.ts
@@ -1,5 +1,6 @@
 // 自動生成ファイル。直接編集禁止。pnpm create-component-d で再生成
 export const miComposableList = [
+    { name: 'useCheckableField', from: 'minazuki-ui' },
     { name: 'useFormData', from: 'minazuki-ui' },
     { name: 'useNotification', from: 'minazuki-ui' },
     { name: 'useTheme', from: 'minazuki-ui' },

--- a/src/nuxt/module.ts
+++ b/src/nuxt/module.ts
@@ -37,7 +37,6 @@ interface _NuxtModule<T> extends _NuxtModuleFn<T> {
     getMeta?: () => Promise<_NuxtModule<T>['meta']>;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _module = defineNuxtModule<ModuleOptions>({
     meta: {
         name: 'minazuki-ui',

--- a/src/test/composables/useCheckableField.spec.ts
+++ b/src/test/composables/useCheckableField.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { defineComponent, h, nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import { useForm } from 'vee-validate';
+import { useCheckableField } from '@/composables/useCheckableField';
+
+function createHarness<T>(fieldName: string, type: 'checkbox' | 'radio', checkedValue: T, uncheckedValue: T) {
+    let result: ReturnType<typeof useCheckableField<T>> | undefined;
+    mount(
+        defineComponent({
+            setup() {
+                useForm();
+                result = useCheckableField(fieldName, type, checkedValue, uncheckedValue) as ReturnType<
+                    typeof useCheckableField<T>
+                >;
+                return () => h('div');
+            }
+        })
+    );
+    return result!;
+}
+
+describe('useCheckableField', () => {
+    it('value / checked / errors / meta / onFieldChange が返される', () => {
+        const result = createHarness('field', 'checkbox', true, false);
+        expect(result.value).toBeDefined();
+        expect(result.checked).toBeDefined();
+        expect(result.errors).toBeDefined();
+        expect(result.meta).toBeDefined();
+        expect(result.onFieldChange).toBeTypeOf('function');
+    });
+
+    it('初期状態では meta.touched が false', () => {
+        const result = createHarness('field-touched-init', 'checkbox', true, false);
+        expect(result.meta.touched).toBe(false);
+    });
+
+    it('onFieldChange を呼ぶと meta.touched が true になる', async () => {
+        const result = createHarness('field-touched', 'checkbox', true, false);
+        result.onFieldChange(true);
+        await nextTick();
+        expect(result.meta.touched).toBe(true);
+    });
+
+    it('onFieldChange(checkedValue) を呼ぶと value が checkedValue になる', async () => {
+        const result = createHarness('field-val', 'checkbox', 'apple', '');
+        result.onFieldChange('apple');
+        await nextTick();
+        expect(result.value.value).toBe('apple');
+    });
+
+    it('onFieldChange(uncheckedValue) を呼ぶと value が uncheckedValue になる', async () => {
+        const result = createHarness('field-uncheck', 'checkbox', 'apple', '');
+        result.onFieldChange('apple');
+        await nextTick();
+        result.onFieldChange('');
+        await nextTick();
+        expect(result.value.value).toBe('');
+    });
+
+    it('type: radio でも正しく動作する', async () => {
+        const result = createHarness('field-radio', 'radio', 'yes', '');
+        result.onFieldChange('yes');
+        await nextTick();
+        expect(result.meta.touched).toBe(true);
+        expect(result.value.value).toBe('yes');
+    });
+});


### PR DESCRIPTION
## Summary

- `src/composables/useCheckableField.ts` を新規作成し、`Checkbox` / `Radio` / `Switch` の 3 コンポーネントで重複していた `useField` + `setTouched(true)` パターンを一元管理
- 各コンポーネントから `useField` の直接呼び出しを除去し `useCheckableField` に差し替え
- `src/test/composables/useCheckableField.spec.ts` を追加（カバレッジ 100%）
- `pnpm create-component-d` によりバレルファイル (`composables/index.ts`, `nuxt/composable-map.ts`) を再生成

## Motivation

closes #763

「touched になるまでエラーを表示しない」というセマンティクスが変わった際に 3 ファイルを同時修正する必要があった問題を解消。将来 checkable 系コンポーネントが追加される際のパターン見落としリスクも低減。

## Test plan

- [x] `pnpm test:run` — 597 tests all pass
- [x] `pnpm type-check` — エラーなし
- [x] `pnpm lint` — エラーなし
- [x] `pnpm test:coverage` — composables / 対象 3 コンポーネントすべて 100%

Generated with [Claude Code](https://claude.ai/code)