### PR TITLE
chore: dependabot の npm エントリを directories + groups で統合

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,29 +6,15 @@ updates:
       interval: 'weekly'
 
   - package-ecosystem: 'npm'
-    directory: '/'
+    directories:
+      - '/'
+      - '/playground/vue'
+      - '/playground/nuxt3'
+      - '/playground/nuxt4'
     schedule:
       interval: 'weekly'
     cooldown:
       default-days: 7
-
-  - package-ecosystem: 'npm'
-    directory: '/playground/vue'
-    schedule:
-      interval: 'weekly'
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: 'npm'
-    directory: '/playground/nuxt3'
-    schedule:
-      interval: 'weekly'
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: 'npm'
-    directory: '/playground/nuxt4'
-    schedule:
-      interval: 'weekly'
-    cooldown:
-      default-days: 7
+    groups:
+      npm-dependencies:
+        group-by: 'dependency-name'


### PR DESCRIPTION
## Summary

- `npm` エコシステムの4エントリ（`/`, `/playground/vue`, `/playground/nuxt3`, `/playground/nuxt4`）を `directories` リストで1エントリに統合
- `groups.npm-dependencies.group-by: dependency-name` を追加し、同一パッケージの更新を全ディレクトリ横断で1つの PR にまとめるよう設定

## Background

zod などの共通パッケージが更新された際に、ディレクトリごとに別々の PR が作成されていた（例: #738, #744, #754）。

`directories` 単体では PR 数の削減効果はなく、`group-by: dependency-name` との組み合わせで初めてクロスディレクトリの PR 統合が実現する。

## Test plan

- [ ] 次回の Dependabot 実行時に、同一パッケージの更新が1 PR にまとまることを確認

Generated with [Claude Code](https://claude.ai/code)