### PR TITLE
fix(playground): Textarea / Autocomplete / DatePicker を Forms ページに追加

### DIFF
--- a/playground/shared/pages/FormsPage.vue
+++ b/playground/shared/pages/FormsPage.vue
@@ -32,12 +32,26 @@ const switchValue = ref(false);
 const checkValue = ref(false);
 const checkGroupValue = ref<string[]>([]);
 const radioValue = ref<string>('');
+const textareaValue = ref('');
+const textareaDisabledValue = ref('あらかじめ入力された値');
+const autocompleteValue = ref('');
+const autocompleteTopValue = ref('');
+const datePickerValue = ref('');
 
 const selectItems = [
     { label: 'オプション A', value: 'a' },
     { label: 'オプション B', value: 'b' },
     { label: 'オプション C', value: 'c' },
     { label: '無効項目', value: 'd', disabled: true }
+];
+
+const autocompleteItems = [
+    { label: 'りんご', value: 'apple', ruby: 'りんご' },
+    { label: 'みかん', value: 'mikan', ruby: 'みかん' },
+    { label: 'ぶどう', value: 'grape', ruby: 'ぶどう' },
+    { label: 'バナナ', value: 'banana', ruby: 'ばなな' },
+    { label: 'いちご', value: 'strawberry', ruby: 'いちご' },
+    { label: '無効項目', value: 'disabled', disabled: true }
 ];
 
 const checkGroupItems = [
@@ -131,6 +145,73 @@ const radioGroupItems = [
                 <MiRadioGroup v-model="radioValue" :items="radioGroupItems" />
                 <span>選択: {{ radioValue || '未選択' }}</span>
             </div>
+        </section>
+
+        <section class="pg-section">
+            <h2>Textarea</h2>
+            <div style="display: flex; flex-direction: column; gap: 12px; max-width: 400px;">
+                <MiTextarea
+                    v-model="textareaValue"
+                    label="メモ"
+                    placeholder="自由に入力してください"
+                    clearable
+                    :line="3"
+                    :min-line="2"
+                    :max-line="6"
+                />
+                <MiTextarea
+                    v-model="textareaDisabledValue"
+                    label="Disabled"
+                    placeholder="無効状態"
+                    disabled
+                />
+                <span>値: {{ textareaValue || '（未入力）' }}</span>
+            </div>
+        </section>
+
+        <section class="pg-section">
+            <h2>Autocomplete</h2>
+            <div style="display: flex; flex-direction: column; gap: 12px; max-width: 400px;">
+                <MiAutocomplete
+                    v-model="autocompleteValue"
+                    :items="autocompleteItems"
+                    label="果物を選択"
+                    placeholder="キーワードで絞り込み"
+                    clearable
+                />
+                <MiAutocomplete
+                    v-model="autocompleteTopValue"
+                    :items="autocompleteItems"
+                    label="上方向に展開（position=top）"
+                    placeholder="キーワードで絞り込み"
+                    position="top"
+                    clearable
+                />
+                <span>下方向: {{ autocompleteValue || '未選択' }} / 上方向: {{ autocompleteTopValue || '未選択' }}</span>
+            </div>
+        </section>
+
+        <section class="pg-section">
+            <h2>DatePicker</h2>
+            <div class="pg-row" style="align-items: flex-start; flex-wrap: wrap; gap: 24px;">
+                <div>
+                    <p style="margin-bottom: 8px;">デフォルト（日本語表示）</p>
+                    <MiDatePicker v-model="datePickerValue" label="日付を選択" />
+                </div>
+                <div>
+                    <p style="margin-bottom: 8px;">スラッシュ区切り</p>
+                    <MiDatePicker
+                        v-model="datePickerValue"
+                        label="日付を選択"
+                        format="YYYY/MM/DD"
+                    />
+                </div>
+                <div>
+                    <p style="margin-bottom: 8px;">Disabled</p>
+                    <MiDatePicker v-model="datePickerValue" label="日付を選択" disabled />
+                </div>
+            </div>
+            <span>値: {{ datePickerValue || '未選択' }}</span>
         </section>
     </div>
 </template>

--- a/playground/shared/pages/FormsPage.vue
+++ b/playground/shared/pages/FormsPage.vue
@@ -193,7 +193,7 @@ const radioGroupItems = [
 
         <section class="pg-section">
             <h2>DatePicker</h2>
-            <div class="pg-row" style="align-items: flex-start; flex-wrap: wrap; gap: 24px;">
+            <div class="pg-row" style=" flex-wrap: wrap; gap: 24px;align-items: flex-start;">
                 <div>
                     <p style="margin-bottom: 8px;">デフォルト（日本語表示）</p>
                     <MiDatePicker v-model="datePickerValue" label="日付を選択" />


### PR DESCRIPTION
## Summary

- `playground/shared/pages/FormsPage.vue` に以下の3コンポーネントのサンプルを追加
  - `MiTextarea` — clearable / min-max行数 / disabled の各バリアントを掲載
  - `MiAutocomplete` — position=bottom / position=top の2パターンを別 ref で管理
  - `MiDatePicker` — 日本語表示 / スラッシュ区切り / disabled の3パターン

- `shared/pages/` への1ファイル修正なので、Nuxt 3 / Nuxt 4 / Vue playground の3環境に自動反映

Closes #773

## Test plan

- [x] Vue playground (`pnpm play:vue`) で4ページを Playwright 確認 → 全ページ描画OK・コンソールエラー0件
- [x] lint (`pnpm lint`) → no issues
- [x] typecheck (`pnpm type-check`) → no errors

Generated with [Claude Code](https://claude.ai/code)