### PR TITLE
fix(datepicker): Nuxt SSR 環境で VueDatePicker が解決されない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,10 +69,10 @@
     "sb:test": "test-storybook --url http://localhost:6006",
     "play:vue": "pnpm --filter playground-vue dev",
     "play:vue:build": "pnpm --filter playground-vue build",
-    "play:nuxt3": "rm -rf playground/nuxt3/.nuxt playground/nuxt3/node_modules/.cache && pnpm --filter playground-nuxt3 dev",
-    "play:nuxt3:build": "pnpm --filter playground-nuxt3 build",
-    "play:nuxt4": "rm -rf playground/nuxt4/.nuxt playground/nuxt4/node_modules/.cache && pnpm --filter playground-nuxt4 dev",
-    "play:nuxt4:build": "pnpm --filter playground-nuxt4 build",
+    "play:nuxt3": "pnpm build:nuxt && rm -rf playground/nuxt3/.nuxt playground/nuxt3/node_modules/.cache && pnpm --filter playground-nuxt3 dev",
+    "play:nuxt3:build": "pnpm build:nuxt && pnpm --filter playground-nuxt3 build",
+    "play:nuxt4": "pnpm build:nuxt && rm -rf playground/nuxt4/.nuxt playground/nuxt4/node_modules/.cache && pnpm --filter playground-nuxt4 dev",
+    "play:nuxt4:build": "pnpm build:nuxt && pnpm --filter playground-nuxt4 build",
     "prepare": "husky"
   },
   "peerDependencies": {

--- a/src/components/controls/DatePicker.vue
+++ b/src/components/controls/DatePicker.vue
@@ -2,6 +2,7 @@
 import { computed, useId, watch, ref } from 'vue';
 import { useField } from 'vee-validate';
 import type { ZodTypeAny } from 'zod';
+import VueDatePicker from '@vuepic/vue-datepicker';
 import { resolveStringChecks } from '@/assets/ts/schema';
 import FieldFrame from '@/components/inner-parts/FieldFrame.vue';
 import { DATE_FORMAT } from '@/assets/ts/const';
@@ -87,8 +88,8 @@ const convertVueDatepickerFormat = (format: MiDateFormat) => {
     return format.replace(/(Y)/g, 'y').replace(/(D)/g, 'd');
 };
 
-const setDayClass = (date: string) => {
-    const weekDay = new Date(date).getDay();
+const setDayClass = (date: Date) => {
+    const weekDay = date.getDay();
     if (weekDay == 6) {
         // 土曜日の場合、classに"saturday"を追加
         return 'saturday';

--- a/src/test/components/controls/DatePicker.spec.ts
+++ b/src/test/components/controls/DatePicker.spec.ts
@@ -50,8 +50,8 @@ describe('DatePicker', () => {
         ['2024-01-08T12:00:00Z', '']
     ])('setDayClass は %s に %s を返す', (dateISO, expectedClass) => {
         const wrapper = mountDP();
-        const dayClass = wrapper.findComponent({ name: 'VueDatePicker' }).props('dayClass') as (d: string) => string;
-        expect(dayClass(dateISO)).toBe(expectedClass);
+        const dayClass = wrapper.findComponent({ name: 'VueDatePicker' }).props('dayClass') as (d: Date) => string;
+        expect(dayClass(new Date(dateISO))).toBe(expectedClass);
     });
 
     it.each([


### PR DESCRIPTION
## Summary

- `DatePicker.vue` が `VueDatePicker` のグローバル登録に依存していたため、Nuxt モジュール（`install: false` デフォルト）環境では `[Vue warn]: Failed to resolve component: VueDatePicker` が発生しカレンダー UI が表示されなかった
- `dist/nuxt/module.mjs` が `pnpm build-only` では生成されず、Nuxt モジュール自体がロードされていなかった（`play:nuxt3/4` 起動時に `build:nuxt` が未実行）
- `setDayClass` の引数型が `string` のままで、`@vuepic/vue-datepicker` の実際の型（`Date`）と不一致だった

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/components/controls/DatePicker.vue` | `VueDatePicker` を直接 import するよう変更 |
| 同上 | `setDayClass` の引数型を `string` → `Date` に修正 |
| `src/test/components/controls/DatePicker.spec.ts` | `dayClass` コールバックに `new Date(dateISO)` を渡すよう修正 |
| `package.json` | `play:nuxt3/4`・`play:nuxt3:build/play:nuxt4:build` に `pnpm build:nuxt` を前置 |

## Test plan

- [x] `pnpm test:run` — 605 tests passed
- [x] `pnpm lint` — no issues
- [x] `pnpm type-check` — no errors
- [x] Nuxt 3 playground `/forms` で DatePicker カレンダー UI が表示されること（Playwright 確認済み）
- [x] Nuxt 4 playground `/forms` で DatePicker カレンダー UI が表示されること（Playwright 確認済み）
- [x] コンソール警告・Hydration エラーなし

Generated with [Claude Code](https://claude.ai/code)