### PR TITLE
fix(field): resetForm 後に未入力バリデーションエラーが復活する問題を修正 (#784)

### DIFF
--- a/playground/shared/pages/FormsPage.vue
+++ b/playground/shared/pages/FormsPage.vue
@@ -10,7 +10,7 @@ const schema = z.object({
     homepage: z.string().url().or(z.literal(''))
 });
 
-const { handleSubmit, canSubmit, values } = useFormData(schema, {
+const { handleSubmit, canSubmit, values, resetForm } = useFormData(schema, {
     name: '',
     email: '',
     homepage: ''
@@ -25,7 +25,13 @@ const onSubmit = handleSubmit(() => {
         message: `名前: ${values.name} / メール: ${values.email}`,
         autoRemove: true
     });
+    // 送信後にフォームをリセット（リセット直後に未入力エラーが復活しないことを確認する）
+    resetForm();
 });
+
+const onReset = () => {
+    resetForm();
+};
 
 const selectValue = ref<string>('');
 const switchValue = ref(false);
@@ -97,9 +103,14 @@ const radioGroupItems = [
                     label="ホームページ（任意）"
                     placeholder="https://example.com"
                 />
-                <MiButton variant="primary" :disabled="!canSubmit" @click="onSubmit">
-                    送信
-                </MiButton>
+                <div class="pg-row">
+                    <MiButton variant="primary" :disabled="!canSubmit" @click="onSubmit">
+                        送信
+                    </MiButton>
+                    <MiButton variant="secondary" @click="onReset">
+                        リセット
+                    </MiButton>
+                </div>
             </div>
         </section>
 

--- a/src/components/controls/Field.vue
+++ b/src/components/controls/Field.vue
@@ -139,7 +139,12 @@ defineEmits<{
 const generatedId = useId();
 const fieldName = computed(() => props.name || generatedId);
 const fieldType = ref(props.type === 'number' ? 'tel' : props.type);
-const { value, errors } = useField<string>(fieldName);
+// validateOnValueUpdate を無効化し、値の代入では自動バリデートを走らせない。
+// これにより resetForm() / model 反映 / 表示⇔値の同期といったプログラム的な値変更で
+// 誤って未入力バリデーションが走るのを防ぐ。バリデートはユーザー入力時に明示的に行う。
+const { value, errors, validate } = useField<string>(fieldName, undefined, {
+    validateOnValueUpdate: false
+});
 if (value.value == null && model.value != null) {
     value.value = model.value;
 }
@@ -163,13 +168,19 @@ const max = computed(
 const formatValue = ref('');
 watch(formatValue, (v) => {
     // フォーマット処理
-
     const formatedValue = props.formatter(v);
     const displayFormatedValue = props.displayFormatter(formatedValue);
     const nativeParsedValue = props.displayParser(formatedValue);
 
-    formatValue.value = displayFormatedValue;
-    value.value = nativeParsedValue;
+    if (formatValue.value !== displayFormatedValue) {
+        formatValue.value = displayFormatedValue;
+    }
+    // value からの伝播（reset / model / DatePicker 等）による往復では同値が返るため、
+    // 実際に値が変わったユーザー入力時のみ value を更新し、その場合だけライブバリデートする。
+    if (value.value !== nativeParsedValue) {
+        value.value = nativeParsedValue;
+        validate();
+    }
 });
 watch(value, (v) => {
     model.value = v;
@@ -183,6 +194,7 @@ const isFocus = ref(false);
 const onDelete = () => {
     formatValue.value = '';
     value.value = '';
+    validate();
 };
 
 // --- ▼ type: Password時の処理 ▼ ---
@@ -215,6 +227,12 @@ const onCloseDatePicker = () => {
     if (datePickerScrollObserver.value) {
         datePickerScrollObserver.value.disconnect();
     }
+};
+// 日付選択はユーザー操作のため、選択確定時に明示的にバリデートする
+// （value 経由の変更は watch では区別できずバリデートされないため）
+const onDatePickerUpdate = () => {
+    validate();
+    onCloseDatePicker();
 };
 onMounted(() => {
     const intersect = (entries: IntersectionObserverEntry[]) => {
@@ -353,7 +371,7 @@ defineExpose({ onCloseDatePicker, isFocus, datePickerScrollObserver });
                 :dataFormat="dataFormat"
                 :variant:="variant"
                 :shape="shape"
-                @update:model-value="onCloseDatePicker"
+                @update:model-value="onDatePickerUpdate"
                 v-outside-click="onOutsideClick"
             />
         </OpacityTransition>

--- a/src/test/components/controls/Field.spec.ts
+++ b/src/test/components/controls/Field.spec.ts
@@ -1,12 +1,22 @@
 import { describe, it, expect, vi } from 'vitest';
-import { nextTick, h } from 'vue';
-import { mount } from '@vue/test-utils';
+import { nextTick, h, defineComponent } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
 import { z } from 'zod';
 import { Form as VeeForm } from 'vee-validate';
 import Field from '@/components/controls/Field.vue';
 import DatePicker from '@/components/controls/DatePicker.vue';
 import FieldFrame from '@/components/inner-parts/FieldFrame.vue';
+import useFormData from '@/composables/useFormData';
 import { uniqueFieldName } from '@/test/utils/uniqueFieldName';
+
+// validate() は fire-and-forget のため、複数マイクロタスク + マクロタスクを消化して
+// バリデーション結果が DOM に反映されるまで待つ
+const settleValidation = async () => {
+    for (let i = 0; i < 6; i++) {
+        await flushPromises();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+};
 
 describe('Field', () => {
     it('label が表示される', () => {
@@ -401,6 +411,81 @@ describe('Field', () => {
         await datePicker.vm.$emit('update:modelValue', '20240115');
         await nextTick();
         expect(wrapper.find('button.input span').text()).not.toBe('');
+    });
+
+    describe('useFormData 連携時のバリデーション挙動', () => {
+        const schema = z.object({ field: z.string().min(1) });
+        const mountWithForm = (extraAttrs = '', initialValues?: Record<string, unknown>) => {
+            const Host = defineComponent({
+                components: { Field },
+                setup() {
+                    const form = useFormData(schema as never, initialValues as never);
+                    return { form };
+                },
+                template: `<Field name="field" ${extraAttrs} />`
+            });
+            const wrapper = mount(Host);
+            const form = (wrapper.vm as { form: ReturnType<typeof useFormData> }).form;
+            return { wrapper, form };
+        };
+
+        it('resetForm() 後に未入力バリデーションエラーが復活しない（#784）', async () => {
+            const { wrapper, form } = mountWithForm();
+            await nextTick();
+
+            // 有効な値を入力（エラーなし）
+            await wrapper.find('input').setValue('入力値');
+            await settleValidation();
+            expect(wrapper.find('.error').exists()).toBe(false);
+
+            // resetForm() で空に戻る。echo による再バリデートでエラーが復活しないこと
+            form.resetForm();
+            await settleValidation();
+            expect(wrapper.find('input').element.value).toBe('');
+            expect(wrapper.find('.error').exists()).toBe(false);
+        });
+
+        it('入力後にクリアすると未入力エラーが表示される', async () => {
+            const { wrapper } = mountWithForm();
+            await nextTick();
+
+            await wrapper.find('input').setValue('a');
+            await settleValidation();
+            expect(wrapper.find('.error').exists()).toBe(false);
+
+            await wrapper.find('input').setValue('');
+            await settleValidation();
+            expect(wrapper.find('.error').exists()).toBe(true);
+        });
+
+        it('送信でエラー表示後、有効値を入力するとエラーが解消し送信可能になる', async () => {
+            const { wrapper, form } = mountWithForm();
+            await nextTick();
+
+            // 未入力で送信 → Required 表示・送信不可
+            await form.handleSubmit(() => {})();
+            await settleValidation();
+            expect(wrapper.find('.error').exists()).toBe(true);
+            expect(form.canSubmit.value).toBe(false);
+
+            // 有効値を入力 → エラー解消・送信可能
+            await wrapper.find('input').setValue('入力値');
+            await settleValidation();
+            expect(wrapper.find('.error').exists()).toBe(false);
+            expect(form.canSubmit.value).toBe(true);
+        });
+
+        it('clearable のクリアで未入力エラーが表示される', async () => {
+            const { wrapper } = mountWithForm('clearable');
+            await nextTick();
+
+            await wrapper.find('input').setValue('入力値');
+            await settleValidation();
+            await wrapper.find('.icon-box:not(.always-visible) svg').trigger('click');
+            await settleValidation();
+            expect(wrapper.find('input').element.value).toBe('');
+            expect(wrapper.find('.error').exists()).toBe(true);
+        });
     });
 
 });


### PR DESCRIPTION
## 概要

Closes #784

`useFormData`（`MiField`）で `resetForm()` を呼ぶと、リセット直後に未入力バリデーションエラー（`min(1)` 等）が表示される問題を修正しました。

## 原因

`MiField`（`Field.vue`）は `formatValue`（表示）と vee-validate の `value`（フィールド値）を相互 watch しており、`validateOnValueUpdate`（デフォルト true）により **`resetForm()` での値変更でも自動バリデートが走り**、未入力エラーが復活していました。

> 補足: issue が原因とした「watcher の直接代入（echo）」は、実際にはこの自動バリデートを偶発的にマスクしていただけで、echo を止めるだけの修正では逆にエラーが復活します。根本原因は `validateOnValueUpdate` による自動バリデートのタイミングでした。

## 修正方針（構造的修正）

- `useField` に **`validateOnValueUpdate: false`** を指定し、値の代入では自動バリデートを走らせない
  - → `resetForm()` / `model` 反映 / 表示⇔値の同期といったプログラム的な値変更で誤バリデートしない
- バリデートは**ユーザー操作時のみ**明示的に実行
  - 入力で値が実際に変化したとき（echo は round-trip で同値になり自然に除外）
  - `clearable` のクリア時
  - DatePicker の日付選択時

これにより「resetForm 後のエラー復活」だけでなく、同じ構造に起因する「入力クリア時のバリデート漏れ」「送信失敗後に値を直してもエラーが消えない」も併せて解消されます。

## 変更点

| ファイル | 内容 |
| --- | --- |
| `src/components/controls/Field.vue` | `validateOnValueUpdate: false` + ユーザー操作時の明示 validate |
| `src/test/components/controls/Field.spec.ts` | 回帰テスト4件追加（reset / クリア / 送信後リカバリ / clearable） |
| `playground/shared/pages/FormsPage.vue` | リセットボタン追加（再現・確認用） |

## 検証

- ユニットテスト: Field 51件パス（無修正だと reset テストが FAIL することを確認済み）
- lint / type-check: パス
- 実ブラウザ動作確認（Playwright）
  - **Vue (CSR)**: reset 後エラー0件・入力空 / ライブ検証（有効→なし、クリア→Required）/ コンソールエラーなし
  - **Nuxt 4 (SSR)**: 同上 + Hydration mismatch なし

Generated with [Claude Code](https://claude.ai/code)