### PR TITLE
fix(field): resolveStringChecks が ZodPipeline / ZodEffects を解決できるよう対応

### DIFF
--- a/src/assets/ts/schema.ts
+++ b/src/assets/ts/schema.ts
@@ -8,8 +8,8 @@ export interface ResolvedStringCheck {
 
 /**
  * 任意の Zod スキーマから ZodString の checks 配列を取り出す。
- * ZodOptional / ZodNullable / ZodDefault などのラッパーや ZodUnion の選択肢を再帰的に解いて
- * 最初に見つかった ZodString の checks を返す。
+ * ZodOptional / ZodNullable / ZodDefault などのラッパーや ZodUnion の選択肢、
+ * ZodPipeline / ZodEffects を再帰的に解いて最初に見つかった ZodString の checks を返す。
  */
 export const resolveStringChecks = (schema?: ZodTypeAny): ResolvedStringCheck[] | undefined => {
     const def = schema?._def as
@@ -18,6 +18,8 @@ export const resolveStringChecks = (schema?: ZodTypeAny): ResolvedStringCheck[] 
               checks?: ResolvedStringCheck[];
               innerType?: ZodTypeAny;
               options?: ZodTypeAny[];
+              in?: ZodTypeAny;
+              schema?: ZodTypeAny;
           }
         | undefined;
     if (!def) return undefined;
@@ -25,6 +27,10 @@ export const resolveStringChecks = (schema?: ZodTypeAny): ResolvedStringCheck[] 
     if (def.typeName === 'ZodString' && def.checks) return def.checks;
     // ZodOptional / ZodNullable / ZodDefault など innerType を持つラッパー
     if (def.innerType) return resolveStringChecks(def.innerType);
+    // ZodPipeline（.pipe()）: 入力スキーマ側の checks を採用
+    if (def.in) return resolveStringChecks(def.in);
+    // ZodEffects（.refine() / .superRefine() / .transform()）: ラップ元スキーマを解決
+    if (def.schema) return resolveStringChecks(def.schema);
     // ZodUnion: 最初に checks を持つ選択肢を採用
     if (def.options) {
         for (const opt of def.options) {

--- a/src/test/assets/schema.spec.ts
+++ b/src/test/assets/schema.spec.ts
@@ -46,6 +46,41 @@ describe('resolveStringChecks', () => {
         expect(checks?.some((c) => c.kind === 'min' && c.value === 1)).toBe(true);
     });
 
+    it('ZodPipeline（.pipe()）の入力スキーマから checks を返す', () => {
+        const schema = z.string().min(1).max(50).pipe(z.string().email());
+        const checks = resolveStringChecks(schema);
+        expect(checks?.some((c) => c.kind === 'min' && c.value === 1)).toBe(true);
+        expect(checks?.some((c) => c.kind === 'max' && c.value === 50)).toBe(true);
+    });
+
+    it('ZodEffects（.refine()）のラップ元スキーマから checks を返す', () => {
+        const schema = z
+            .string()
+            .min(1)
+            .refine((v) => v.length > 0);
+        const checks = resolveStringChecks(schema);
+        expect(checks?.some((c) => c.kind === 'min' && c.value === 1)).toBe(true);
+    });
+
+    it('ZodEffects（.transform()）のラップ元スキーマから checks を返す', () => {
+        const schema = z
+            .string()
+            .max(20)
+            .transform((v) => v.trim());
+        const checks = resolveStringChecks(schema);
+        expect(checks?.some((c) => c.kind === 'max' && c.value === 20)).toBe(true);
+    });
+
+    it('ZodPipeline と ZodEffects の入れ子も解決する', () => {
+        const schema = z
+            .string()
+            .min(1)
+            .pipe(z.string().email())
+            .refine((v) => v.includes('@'));
+        const checks = resolveStringChecks(schema);
+        expect(checks?.some((c) => c.kind === 'min' && c.value === 1)).toBe(true);
+    });
+
     it('ZodString を含まないスキーマ（ZodNumber）では undefined を返す', () => {
         const schema = z.number();
         expect(resolveStringChecks(schema)).toBeUndefined();


### PR DESCRIPTION
## 概要

`MiField` の `:schema` に `ZodPipeline`（`.pipe()`）や `ZodEffects`（`.refine()` / `.superRefine()` / `.transform()`）でラップした ZodString を渡すと、`resolveStringChecks` が `min` / `max` チェックを辿れず、必須マーク（*）や maxlength ヒントが失われる問題を修正します。

Closes #785

## 原因

`src/assets/ts/schema.ts` の `resolveStringChecks` は `checks` / `innerType` / `options` のみを辿る。

- `ZodPipeline._def` = `{ in, out, typeName }` → `_def.in` が ZodString
- `ZodEffects._def` = `{ schema, typeName, effect }` → `_def.schema` が ZodString

いずれも辿られず `undefined` を返すため、`Field.vue` の `isRequired` が `props.required`（既定 false）にフォールバックして必須マークが消えていた。

## 修正

`resolveStringChecks` に分岐を追加し、既存の `innerType` / `options` と同じ「プロパティ存在判定 → 再帰」パターンで解決する。

- `ZodPipeline`: `_def.in` を再帰解決
- `ZodEffects`: `_def.schema` を再帰解決

Issue では `typeName === 'ZodPipeline'` 判定が提案されていたが、`in` / `schema` は各型固有のため、typeName 文字列依存を増やさずプロパティ存在判定に統一した。

## テスト

`src/test/assets/schema.spec.ts` に追加（計 12 件パス）:

- `.pipe()` の min/max 解決
- `.refine()` / `.transform()` の解決
- pipeline + effects の入れ子解決

## 検証

- `pnpm test:run` ✅
- `pnpm type-check` ✅
- `pnpm lint` ✅

Generated with [Claude Code](https://claude.ai/code)