### PR TITLE
fix(style): lucide のグローバルサイズ指定を :where() でラップし詳細度を 0 に

### DIFF
--- a/src/assets/css/override.css
+++ b/src/assets/css/override.css
@@ -2,7 +2,7 @@
 
 /* lucideのオーバーライド */
 
-.lucide {
+:where(.lucide) {
     width: var(--font-size-medium);
     height: var(--font-size-medium);
 }


### PR DESCRIPTION
## 概要

素の `.lucide`（詳細度 `(0,1,0)`）グローバルセレクタが、minazuki-ui を利用する消費側アプリの全 lucide アイコンにサイズを強制し、特異度争いを引き起こしていた問題を修正する。

`:where()` でラップして詳細度を `(0,0,0)` に落とすことで、消費側の任意ルールが特異度争いなく上書きできるようにする。

```css
:where(.lucide) {
    width: var(--font-size-medium);
    height: var(--font-size-medium);
}
```

## 影響範囲

- ライブラリ内部のコンポーネントアイコンは `data-v` でスコープ済み（より高い詳細度）のため挙動は不変。
- スロット用フォールバックとしてのデフォルトサイズは維持される。

## 検証

- lint 通過
- 再ビルドで `dist/style.css` に `:where(.lucide)` 反映を確認
- Playwright で Vue playground 全4ページ（Home / Forms / Feedback / Navigation）の描画・コンソールを確認、問題なし
- Navigation の BottomNav アイコンの縦伸びは変更前ビルドでも同一であることを確認済み（本変更とは無関係な既存挙動。別 issue で管理）

Closes #791

Generated with [Claude Code](https://claude.ai/code)