### PR TITLE
fix(useTheme): Node 26 SSR の localStorage ExperimentalWarning を解消

### DIFF
--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -70,8 +70,11 @@ export interface MiTheme
 }
 
 // global state
+// Node 22.4+ では bare な localStorage が globalThis の遅延 getter になり、参照だけで
+// ExperimentalWarning が発火する。window 経由でアクセスすれば SSR（window 不在）では
+// 触れず、Node のグローバル getter を踏まない。
 const currentTheme = ref<themeId>(
-    typeof localStorage !== 'undefined' ? localStorage.themeId ?? 'light' : 'light'
+    typeof window !== 'undefined' ? window.localStorage.themeId ?? 'light' : 'light'
 );
 const baseTheme: MiTheme = {
     base: {
@@ -200,8 +203,8 @@ const setTheme = (themeId: string) => {
         });
     }
 
-    if (typeof localStorage !== 'undefined') {
-        localStorage.setItem('themeId', themeId);
+    if (typeof window !== 'undefined') {
+        window.localStorage.setItem('themeId', themeId);
     }
 };
 

--- a/src/test/composables/useTheme.spec.ts
+++ b/src/test/composables/useTheme.spec.ts
@@ -15,7 +15,7 @@ describe('useTheme', () => {
     const initialThemesSnapshot = JSON.parse(JSON.stringify(themes.value));
 
     beforeEach(() => {
-        (globalThis as any).localStorage?.removeItem('themeId');
+        window.localStorage?.removeItem('themeId');
         themes.value = JSON.parse(JSON.stringify(initialThemesSnapshot));
         document.body.removeAttribute('data-theme');
         document.getElementById(THEME_STYLE_ID)?.remove();
@@ -87,21 +87,21 @@ describe('useTheme', () => {
         themes.value = savedThemes;
     });
 
-    it('localStorage が存在しない場合も setTheme が正常に完了する', () => {
+    it('window が存在しない（SSR）環境でも setTheme が正常に完了する', () => {
         const { setTheme } = useTheme();
 
-        const savedLocalStorage = (globalThis as any).localStorage;
-        (globalThis as any).localStorage = undefined;
+        const savedWindow = (globalThis as any).window;
+        (globalThis as any).window = undefined;
 
         expect(() => setTheme('light')).not.toThrow();
         expect(document.body.getAttribute('data-theme')).toBe('light');
 
-        (globalThis as any).localStorage = savedLocalStorage;
+        (globalThis as any).window = savedWindow;
     });
 
-    it('localStorage が存在しない環境での currentTheme のデフォルト値は light', async () => {
-        const savedLocalStorage = (globalThis as any).localStorage;
-        (globalThis as any).localStorage = undefined;
+    it('window が存在しない（SSR）環境での currentTheme のデフォルト値は light', async () => {
+        const savedWindow = (globalThis as any).window;
+        (globalThis as any).window = undefined;
 
         vi.resetModules();
         vi.doMock('@unhead/vue', () => ({ useHead: vi.fn() }));
@@ -110,12 +110,12 @@ describe('useTheme', () => {
 
         expect(currentTheme.value).toBe('light');
 
-        (globalThis as any).localStorage = savedLocalStorage;
+        (globalThis as any).window = savedWindow;
         vi.resetModules();
     });
 
     it('localStorage.themeId に値が入っている場合はその値が currentTheme の初期値になる', async () => {
-        localStorage.setItem('themeId', 'dark');
+        window.localStorage.setItem('themeId', 'dark');
 
         vi.resetModules();
         vi.doMock('@unhead/vue', () => ({ useHead: vi.fn() }));
@@ -124,7 +124,7 @@ describe('useTheme', () => {
 
         expect(currentTheme.value).toBe('dark');
 
-        localStorage.removeItem('themeId');
+        window.localStorage.removeItem('themeId');
         vi.resetModules();
     });
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -20,3 +20,40 @@ class ResizeObserverStub {
 if (!globalThis.ResizeObserver) {
     globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
 }
+
+// この happy-dom + Node 26 環境では window.localStorage が undefined を返し機能しないため、
+// 実ブラウザ相当の動作する Storage を window に注入する（useTheme の動作確認用）。
+// 実 Storage は `storage.foo` の名前付きプロパティアクセスもサポートするため Proxy で再現する。
+if (typeof window !== 'undefined' && !window.localStorage) {
+    const createStorage = (): Storage => {
+        const store: Record<string, string> = {};
+        const api = {
+            getItem: (key: string) => (key in store ? store[key] : null),
+            setItem: (key: string, value: string) => {
+                store[key] = String(value);
+            },
+            removeItem: (key: string) => {
+                delete store[key];
+            },
+            clear: () => {
+                for (const key of Object.keys(store)) delete store[key];
+            },
+            key: (index: number) => Object.keys(store)[index] ?? null,
+            get length() {
+                return Object.keys(store).length;
+            }
+        };
+        return new Proxy(api, {
+            get: (target, prop: string) =>
+                prop in target ? (target as never)[prop] : store[prop],
+            set: (_target, prop: string, value) => {
+                store[prop] = String(value);
+                return true;
+            }
+        }) as unknown as Storage;
+    };
+    Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        value: createStorage()
+    });
+}


### PR DESCRIPTION
## 概要

Closes #793

Node 26 環境の SSR で `useTheme` のモジュール評価時に下記の Node 実験警告が出ていた問題を修正する。

```
(node:xxxxx) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
```

## 根本原因

`src/composables/useTheme.ts` が `typeof localStorage !== 'undefined'` で存在チェックしていた。Node 22.4+ では bare な `localStorage` が globalThis の**遅延 getter** として定義され、`typeof` 参照だけでも getter が発火して ExperimentalWarning を出す（その後 `undefined` を返す）。旧 Node では `localStorage` グローバル自体が未定義だったため発火しなかった。

## 対応

- 判定・アクセスの両方を `window.localStorage` 経由に統一（2 箇所）。
  - issue 案は判定のみ `window` に変える内容だったが、bare `localStorage` 参照が残ると window はあるが Storage が機能しない環境で `localStorage.themeId` 参照が throw する。`window.localStorage` に統一して bare 参照そのものを排除した。
  - SSR では `typeof window !== 'undefined'` で短絡し、Node のグローバル getter を一切踏まない。
- テストの SSR シミュレーションを `localStorage=undefined` → `window=undefined` に変更。
- happy-dom + Node 26 では `window.localStorage` が機能しないため、test setup に動作する Storage polyfill（名前付きプロパティアクセス対応の Proxy）を注入。

## 検証

- 素の Node SSR（window 不在）で新パターンは**警告なし**、旧パターンは**発火**することを実証
- `pnpm test:run`: 616 件全通過
- `useTheme.ts` カバレッジ **100%**（stmts / branch / funcs / lines）
- `pnpm type-check` / `pnpm lint`: エラーなし

UI・スタイル変更ではないため playground 整備・Playwright 確認は不要。

Generated with [Claude Code](https://claude.ai/code)