### PR TITLE
ci: pnpm setup を再利用可能な composite action に切り出し

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,54 @@
+name: Setup Node & pnpm
+description: >
+  Corepack 経由で pnpm を有効化し、Node をセットアップ、pnpm の store とメタデータを
+  restore-keys 付きでキャッシュしてから frozen install する共通セットアップ。
+  lockfile が変わってもキャッシュは直近のものから復元されるため、minimumReleaseAge の
+  サプライチェーン検証が全件レジストリ問い合わせ（コールド）になるのを防ぐ。
+  外部 action は本リポの方針に合わせて SHA ピンする。
+
+inputs:
+  node-version:
+    description: Node.js のバージョン
+    required: false
+    default: '24'
+
+runs:
+  using: composite
+  steps:
+    - name: Enable corepack
+      shell: bash
+      env:
+        # corepack が pnpm を取得する際の署名検証を無効化（CI で integrity keys が無い環境向け）
+        COREPACK_INTEGRITY_KEYS: '0'
+      run: |
+        npm install -g corepack@latest
+        corepack enable
+
+    - name: Setup Node
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Resolve pnpm store dir
+      id: store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm store & metadata
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        # store=パッケージ本体、~/.cache/pnpm=レジストリのメタデータ（公開日含む）。
+        # 後者が効くと minimumReleaseAge の検証がオフラインで済む。
+        path: |
+          ${{ steps.store.outputs.path }}
+          ~/.cache/pnpm
+        key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        # 完全一致が無くても直近の pnpm-<os>-* を復元し、差分だけ取得・検証する
+        restore-keys: |
+          pnpm-${{ runner.os }}-
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        COREPACK_INTEGRITY_KEYS: '0'
+      run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -18,18 +18,8 @@ jobs:
         env:
           COREPACK_INTEGRITY_KEYS: 0
 
-      - name: Enable corepack
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm i --frozen-lockfile
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run Build
         run: pnpm build

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -17,18 +17,8 @@ jobs:
         env:
           COREPACK_INTEGRITY_KEYS: 0
 
-      - name: Enable corepack
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm i --frozen-lockfile
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run linter
         run: pnpm lint

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -21,18 +21,8 @@ jobs:
         env:
           COREPACK_INTEGRITY_KEYS: 0
 
-      - name: Enable corepack
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm i --frozen-lockfile
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run tests with coverage
         run: pnpm test:coverage


### PR DESCRIPTION
## 概要

`pr-lint` / `pr-test` / `pr-build` が**同じ corepack + setup-node + frozen install を繰り返し**ていたので、再利用可能な composite action `.github/actions/setup` に切り出した（[furutsubaki/shigurezuki#940](https://github.com/furutsubaki/shigurezuki/issues/940) の水平展開。shigurezuki / payload と同系統）。

## 変更

- `.github/actions/setup/action.yml` を追加
  - pnpm の store＋メタデータ（`~/.cache/pnpm`）を `actions/cache` で **`restore-keys` 付き**キャッシュ＋`--prefer-offline`
  - 外部 action は**SHA ピン**（本リポの方針に合わせる）: `actions/setup-node@v4.4.0` / `actions/cache@v5.0.5`
  - `node-version` は input（**default 24**）
- `pr-lint.yml` / `pr-test.yml` / `pr-build.yml` の「corepack / setup-node / install」を `uses: ./.github/actions/setup` に置換

## 効果

本リポは `pnpm-workspace.yaml` に **`minimumReleaseAge: 10080`** があるため、lockfile 変更時にサプライチェーン検証が全エントリのレジストリ問い合わせ（コールド）になり遅延・フレークしやすい。restore-keys キャッシュで直近キャッシュから復元し、**差分だけ検証**して回避する。

## 方針

- **ジョブ名は不変**（lint / test / build）→ branch protection の必須チェックはそのまま満たされる（設定変更不要）
- `release-package.yml` は**対象外**（npm publish 用に setup-node の `registry-url` / `scope` が必要なため、共通 action には寄せない）

Generated with [Claude Code](https://claude.ai/code)
