### PR TITLE
ci: setup-node を v6.4.0 に統一（Node20 deprecation 解消）

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,7 +25,7 @@ runs:
         corepack enable
 
     - name: Setup Node
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -22,7 +22,7 @@ jobs:
           npm install -g corepack@latest
           corepack enable
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: 'pnpm'


### PR DESCRIPTION
## 概要

`actions/setup-node` を **v4.4.0 → v6.4.0**（SHA ピン）に統一する。

## 背景

setup-node v4.4.0 は Node 20 ランタイムで動作し、GitHub が Node 24 へ強制実行しつつ **deprecation 警告**を出す（#800 の CI でも `Node.js 20 is deprecated` のアノテーションが出ていた）。v6.4.0 は Node 24 ネイティブで警告が出ない。

## 変更

以下2箇所の setup-node を v6.4.0 SHA ピンに更新:

- `.github/actions/setup/action.yml`（共通 setup action）
- `.github/workflows/release-package.yml`

shigurezuki のワークフローが使う setup-node v6 と整合。`actions/cache` は #800 で既に v5.0.5（Node 24）。

## 検証

pr-lint / pr-test がこの PR の CI で共通 action（v6 setup-node）を実行するので、緑を確認すれば動作 OK。

Generated with [Claude Code](https://claude.ai/code)
