### PR TITLE
fix(plugins): initValidate から i18next/zod-i18n-map を撤去し自前の日本語 ZodErrorMap に置換

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,13 +82,11 @@
     "@vee-validate/zod": ">=4.9.0",
     "@vuepic/vue-datepicker": ">=11.0.0",
     "dayjs": ">=1.0.0",
-    "i18next": ">=23.0.0",
     "lucide-vue-next": ">=0.356.0",
     "vee-validate": ">=4.9.0",
     "vue": ">=3.5.0",
     "vue-router": ">=4.0.0",
-    "zod": ">=3.20.0 <4.0.0",
-    "zod-i18n-map": ">=2.0.0"
+    "zod": ">=3.20.0 <4.0.0"
   },
   "peerDependenciesMeta": {
     "@nuxt/kit": {

--- a/playground/nuxt3/package.json
+++ b/playground/nuxt3/package.json
@@ -18,14 +18,12 @@
     "@vee-validate/zod": "^4",
     "@vuepic/vue-datepicker": "^11",
     "dayjs": "^1",
-    "i18next": "^23",
     "lucide-vue-next": ">=0.356.0",
     "nuxt": "^3.21.6",
     "pinia": "^3",
     "vee-validate": "^4",
     "zod": "^3",
-    "vue": "^3.5",
-    "zod-i18n-map": "^2"
+    "vue": "^3.5"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/playground/nuxt4/package.json
+++ b/playground/nuxt4/package.json
@@ -18,14 +18,12 @@
     "@vee-validate/zod": "^4",
     "@vuepic/vue-datepicker": "^11",
     "dayjs": "^1",
-    "i18next": "^23",
     "lucide-vue-next": ">=0.356.0",
     "nuxt": "^4.4.6",
     "vue": "^3.5",
     "pinia": "^2",
     "vee-validate": "^4",
-    "zod": "^3",
-    "zod-i18n-map": "^2"
+    "zod": "^3"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/playground/vue/package.json
+++ b/playground/vue/package.json
@@ -18,15 +18,13 @@
     "@vee-validate/zod": "^4",
     "@vuepic/vue-datepicker": "^11",
     "dayjs": "^1",
-    "i18next": "^23",
     "lucide-vue-next": ">=0.356.0",
     "minazuki-ui": "workspace:*",
     "pinia": "^2",
     "vee-validate": "^4",
     "vue": "^3.5.34",
     "vue-router": "^4",
-    "zod": "^3",
-    "zod-i18n-map": "^2"
+    "zod": "^3"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,9 +222,6 @@ importers:
       dayjs:
         specifier: '>=1.0.0'
         version: 1.11.20
-      i18next:
-        specifier: '>=23.0.0'
-        version: 23.16.8
       lucide-vue-next:
         specifier: '>=0.356.0'
         version: 1.0.0(vue@3.5.34(typescript@5.8.3))
@@ -240,9 +237,6 @@ importers:
       zod:
         specifier: '>=3.20.0 <4.0.0'
         version: 3.25.76
-      zod-i18n-map:
-        specifier: '>=2.0.0'
-        version: 2.27.0(i18next@23.16.8)(zod@3.25.76)
     devDependencies:
       '@acab/reset.css':
         specifier: ^0.11.0
@@ -388,9 +382,6 @@ importers:
       dayjs:
         specifier: ^1
         version: 1.11.20
-      i18next:
-        specifier: ^23
-        version: 23.16.8
       lucide-vue-next:
         specifier: '>=0.356.0'
         version: 1.0.0(vue@3.5.34(typescript@5.8.3))
@@ -415,9 +406,6 @@ importers:
       zod:
         specifier: ^3
         version: 3.25.76
-      zod-i18n-map:
-        specifier: ^2
-        version: 2.27.0(i18next@23.16.8)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^22
@@ -449,9 +437,6 @@ importers:
       dayjs:
         specifier: ^1
         version: 1.11.20
-      i18next:
-        specifier: ^23
-        version: 23.16.8
       lucide-vue-next:
         specifier: '>=0.356.0'
         version: 1.0.0(vue@3.5.34(typescript@5.8.3))
@@ -476,9 +461,6 @@ importers:
       zod:
         specifier: ^3
         version: 3.25.76
-      zod-i18n-map:
-        specifier: ^2
-        version: 2.27.0(i18next@23.16.8)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^22
@@ -522,9 +504,6 @@ importers:
       dayjs:
         specifier: ^1
         version: 1.11.20
-      i18next:
-        specifier: ^23
-        version: 23.16.8
       lucide-vue-next:
         specifier: '>=0.356.0'
         version: 1.0.0(vue@3.5.34(typescript@5.8.3))
@@ -549,9 +528,6 @@ importers:
       zod:
         specifier: ^3
         version: 3.25.76
-      zod-i18n-map:
-        specifier: ^2
-        version: 2.27.0(i18next@23.16.8)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^22
@@ -3971,9 +3947,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  i18next@23.16.8:
-    resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
-
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -6418,12 +6391,6 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
-
-  zod-i18n-map@2.27.0:
-    resolution: {integrity: sha512-ORu9XpiVh3WDiEUs5Cr9siGgnpeODoBsTIgSD8sQCH9B//f9KowlzqHUEdPYb3vFonaSH8yPvPCOFM4niwp3Sg==}
-    peerDependencies:
-      i18next: '>=21.3.0'
-      zod: '>=3.17.0'
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -10063,10 +10030,6 @@ snapshots:
 
   husky@9.1.7: {}
 
-  i18next@23.16.8:
-    dependencies:
-      '@babel/runtime': 7.29.2
-
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -12888,10 +12851,5 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
-
-  zod-i18n-map@2.27.0(i18next@23.16.8)(zod@3.25.76):
-    dependencies:
-      i18next: 23.16.8
-      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/src/plugins/init-validate.ts
+++ b/src/plugins/init-validate.ts
@@ -1,36 +1,172 @@
-import { init } from 'i18next';
 import { z } from 'zod';
-import { zodI18nMap } from 'zod-i18n-map';
-import translation from 'zod-i18n-map/locales/ja/zod.json';
 
-const customErrorMap: z.ZodErrorMap = (issue, ctx) => {
+const TYPE_LABELS: Record<string, string> = {
+    function: '関数',
+    number: '数値',
+    string: '文字列',
+    nan: 'NaN',
+    integer: '整数',
+    float: '浮動小数点数',
+    boolean: '真偽値',
+    date: '日時',
+    bigint: 'Bigint',
+    undefined: 'undefined',
+    symbol: 'シンボル',
+    null: 'NULL',
+    array: '配列',
+    object: 'オブジェクト',
+    unknown: 'unknown',
+    promise: 'Promise',
+    void: 'void',
+    never: 'never',
+    map: 'マップ',
+    set: 'セット'
+};
+
+const VALIDATION_LABELS: Record<string, string> = {
+    email: 'メールアドレス',
+    url: 'URL',
+    uuid: 'UUID',
+    cuid: 'CUID',
+    datetime: '日時'
+};
+
+let initialized = false;
+
+function invalidStringMessage(issue: z.ZodInvalidStringIssue): string {
+    const v = issue.validation;
+    if (typeof v === 'object') {
+        if ('includes' in v) return `"${v.includes}"を含む文字列である必要があります`;
+        if ('startsWith' in v) return `"${v.startsWith}"で始まる文字列である必要があります`;
+        if ('endsWith' in v) return `"${v.endsWith}"で終わる文字列である必要があります`;
+        return '入力形式が間違っています';
+    }
+    const label = VALIDATION_LABELS[v];
+    if (label) return `${label}の形式で入力してください`;
+    return '入力形式が間違っています';
+}
+
+function tooSmallMessage(issue: z.ZodTooSmallIssue): string {
+    const v = String(issue.minimum);
+    switch (issue.type) {
+        case 'string':
+            if (issue.exact) return `${v}文字の文字列である必要があります`;
+            if (issue.inclusive) return `${v}文字以上の文字列である必要があります`;
+            return `${v}文字より長い文字列である必要があります`;
+        case 'number':
+        case 'bigint':
+            if (issue.exact) return `${v}の数値である必要があります`;
+            if (issue.inclusive) return `${v}以上の数値である必要があります`;
+            return `${v}より大きな数値である必要があります`;
+        case 'array':
+            if (issue.exact) return `${v}個の要素が必要です`;
+            if (issue.inclusive) return `${v}個以上の要素が必要です`;
+            return `${v}個より多くの要素が必要です`;
+        case 'date': {
+            const d = new Date(Number(issue.minimum)).toLocaleDateString('ja-JP');
+            if (issue.exact) return `${d}の日時である必要があります`;
+            if (issue.inclusive) return `${d}以降の日時である必要があります`;
+            return `${d}よりも後の日時である必要があります`;
+        }
+        default:
+            return '入力形式が間違っています';
+    }
+}
+
+function tooBigMessage(issue: z.ZodTooBigIssue): string {
+    const v = String(issue.maximum);
+    switch (issue.type) {
+        case 'string':
+            if (issue.exact) return `${v}文字の文字列である必要があります`;
+            if (issue.inclusive) return `${v}文字以下の文字列である必要があります`;
+            return `${v}文字より短い文字列である必要があります`;
+        case 'number':
+        case 'bigint':
+            if (issue.exact) return `${v}の数値である必要があります`;
+            if (issue.inclusive) return `${v}以下の数値である必要があります`;
+            return `${v}より小さな数値である必要があります`;
+        case 'array':
+            if (issue.exact) return `${v}個の要素である必要があります`;
+            if (issue.inclusive) return `${v}個以下の要素である必要があります`;
+            return `${v}個より少ない要素である必要があります`;
+        case 'date': {
+            const d = new Date(Number(issue.maximum)).toLocaleDateString('ja-JP');
+            if (issue.exact) return `${d}の日時である必要があります`;
+            if (issue.inclusive) return `${d}以前の日時である必要があります`;
+            return `${d}よりも前の日時である必要があります`;
+        }
+        default:
+            return '入力形式が間違っています';
+    }
+}
+
+export const jaErrorMap: z.ZodErrorMap = (issue, ctx) => {
     switch (issue.code) {
-        case z.ZodIssueCode.invalid_literal:
-            if (issue.expected && !issue.received) {
-                return { message: 'チェックしてください。' };
-            }
-            break;
-        case z.ZodIssueCode.too_small:
-            if (issue.minimum === 1) {
-                return { message: 'この項目は必須項目です。' };
-            }
-            break;
         case z.ZodIssueCode.invalid_type:
             if ([null, undefined, ''].includes(ctx.data)) {
-                return { message: 'この項目は必須項目です。' };
+                return { message: 'この項目は必須項目です' };
             }
-            break;
+            return {
+                message: `${TYPE_LABELS[issue.expected] ?? issue.expected}での入力を期待していますが、${TYPE_LABELS[issue.received] ?? issue.received}が入力されました`
+            };
+
+        case z.ZodIssueCode.invalid_literal:
+            if (issue.expected && !issue.received) {
+                return { message: 'チェックしてください' };
+            }
+            return { message: `無効なリテラル値です。${String(issue.expected)}を入力してください` };
+
+        case z.ZodIssueCode.unrecognized_keys:
+            return { message: `オブジェクトのキー${issue.keys.map(k => `'${k}'`).join(', ')}が識別できません` };
+
+        case z.ZodIssueCode.invalid_union:
+            return { message: '入力形式が間違っています' };
+
+        case z.ZodIssueCode.invalid_union_discriminator:
+            return { message: `無効な識別子です。${issue.options.map(o => `'${String(o)}'`).join(', ')}で入力してください` };
+
+        case z.ZodIssueCode.invalid_enum_value:
+            return { message: `'${issue.received}'は無効な値です。${issue.options.map(o => `'${String(o)}'`).join(', ')}で入力してください` };
+
+        case z.ZodIssueCode.invalid_arguments:
+            return { message: '引数が間違っています' };
+
+        case z.ZodIssueCode.invalid_return_type:
+            return { message: '返値の型が間違っています' };
+
+        case z.ZodIssueCode.invalid_date:
+            return { message: '間違った日時データです' };
+
+        case z.ZodIssueCode.invalid_string:
+            return { message: invalidStringMessage(issue) };
+
+        case z.ZodIssueCode.too_small:
+            if (issue.minimum === 1) {
+                return { message: 'この項目は必須項目です' };
+            }
+            return { message: tooSmallMessage(issue) };
+
+        case z.ZodIssueCode.too_big:
+            return { message: tooBigMessage(issue) };
+
+        case z.ZodIssueCode.custom:
+            return { message: '入力形式が間違っています' };
+
+        case z.ZodIssueCode.invalid_intersection_types:
+            return { message: '交差型のマージができませんでした' };
+
+        case z.ZodIssueCode.not_multiple_of:
+            return { message: `${issue.multipleOf}の倍数である必要があります` };
+
+        case z.ZodIssueCode.not_finite:
+            return { message: '有限数である必要があります' };
     }
-    return zodI18nMap(issue, ctx);
+
+    return { message: ctx.defaultError };
 };
 
 export default () => {
-    // zod
-    init({
-        lng: 'ja',
-        resources: {
-            ja: { zod: translation }
-        }
-    });
-    z.setErrorMap(customErrorMap);
+    if (initialized) return;
+    initialized = true;
+    z.setErrorMap(jaErrorMap);
 };

--- a/src/test/plugins/init-validate.spec.ts
+++ b/src/test/plugins/init-validate.spec.ts
@@ -1,28 +1,320 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { z } from 'zod';
-import initValidate from '@/plugins/init-validate';
+import initValidate, { jaErrorMap } from '@/plugins/init-validate';
+
+function msg(schema: z.ZodTypeAny, input: unknown): string {
+    const result = schema.safeParse(input);
+    if (result.success) throw new Error('Expected validation to fail');
+    return result.error.errors[0].message;
+}
 
 describe('init-validate', () => {
     beforeAll(() => {
         initValidate();
     });
 
-    it.each([
-        [z.literal(true), false, 'チェックしてください。', true],
-        [z.string().min(1), '', 'この項目は必須項目です。', true],
-        [z.string(), null, 'この項目は必須項目です。', true],
-        [z.literal(true), 1, 'チェックしてください。', false],
-        [z.string().min(2), 'a', 'この項目は必須項目です。', false],
-        [z.string(), 123, 'この項目は必須項目です。', false]
-    ])('schema=%o, input=%o のとき message が期待通り', (schema, input, expectedMessage, shouldMatch) => {
-        const result = (schema as z.ZodTypeAny).safeParse(input);
-        expect(result.success).toBe(false);
-        if (!result.success) {
-            if (shouldMatch) {
-                expect(result.error.errors[0].message).toBe(expectedMessage);
-            } else {
-                expect(result.error.errors[0].message).not.toBe(expectedMessage);
-            }
-        }
+    it('再呼び出しでもエラーにならない', () => {
+        expect(() => initValidate()).not.toThrow();
+        expect(msg(z.string().min(1), '')).toBe('この項目は必須項目です');
+    });
+
+    describe('invalid_type', () => {
+        it.each([
+            [z.string(), null, 'この項目は必須項目です'],
+            [z.string(), undefined, 'この項目は必須項目です'],
+            [z.number(), '', 'この項目は必須項目です'],
+            [z.string(), 123, '文字列での入力を期待していますが、数値が入力されました']
+        ])('schema=%o, input=%o → %s', (schema, input, expected) => {
+            expect(msg(schema, input)).toBe(expected);
+        });
+    });
+
+    describe('invalid_literal', () => {
+        it.each([
+            [z.literal(true), false, 'チェックしてください'],
+            [z.literal(true), 1, '無効なリテラル値です。trueを入力してください']
+        ])('schema=%o, input=%o → %s', (schema, input, expected) => {
+            expect(msg(schema, input)).toBe(expected);
+        });
+    });
+
+    describe('unrecognized_keys', () => {
+        it('余分なキーを検出する', () => {
+            const schema = z.object({}).strict();
+            expect(msg(schema, { a: 1 })).toBe("オブジェクトのキー'a'が識別できません");
+        });
+    });
+
+    describe('invalid_union', () => {
+        it('union 不一致', () => {
+            const schema = z.union([z.string(), z.number()]);
+            expect(msg(schema, true)).toBe('入力形式が間違っています');
+        });
+    });
+
+    describe('invalid_union_discriminator', () => {
+        it('discriminated union 不一致', () => {
+            const schema = z.discriminatedUnion('type', [
+                z.object({ type: z.literal('a'), v: z.string() }),
+                z.object({ type: z.literal('b'), v: z.number() })
+            ]);
+            expect(msg(schema, { type: 'c' })).toBe("無効な識別子です。'a', 'b'で入力してください");
+        });
+    });
+
+    describe('invalid_enum_value', () => {
+        it('enum 不一致', () => {
+            const schema = z.enum(['x', 'y']);
+            expect(msg(schema, 'z')).toBe("'z'は無効な値です。'x', 'y'で入力してください");
+        });
+    });
+
+    describe('invalid_date', () => {
+        it('不正な日時', () => {
+            const schema = z.date();
+            expect(msg(schema, new Date('invalid'))).toBe('間違った日時データです');
+        });
+    });
+
+    describe('invalid_string', () => {
+        it.each([
+            [z.string().email(), 'bad', 'メールアドレスの形式で入力してください'],
+            [z.string().url(), 'bad', 'URLの形式で入力してください'],
+            [z.string().uuid(), 'bad', 'UUIDの形式で入力してください'],
+            [z.string().cuid(), 'bad', 'CUIDの形式で入力してください'],
+            [z.string().datetime(), 'bad', '日時の形式で入力してください'],
+            [z.string().regex(/^\d+$/), 'abc', '入力形式が間違っています'],
+            [z.string().includes('foo'), 'bar', '"foo"を含む文字列である必要があります'],
+            [z.string().startsWith('foo'), 'bar', '"foo"で始まる文字列である必要があります'],
+            [z.string().endsWith('foo'), 'bar', '"foo"で終わる文字列である必要があります']
+        ])('schema=%o, input=%s → %s', (schema, input, expected) => {
+            expect(msg(schema, input)).toBe(expected);
+        });
+    });
+
+    describe('too_small', () => {
+        it.each([
+            [z.string().min(1), '', 'この項目は必須項目です'],
+            [z.string().min(3), 'ab', '3文字以上の文字列である必要があります'],
+            [z.string().length(5), 'ab', '5文字の文字列である必要があります'],
+            [z.number().gte(5), 3, '5以上の数値である必要があります'],
+            [z.number().gt(5), 5, '5より大きな数値である必要があります'],
+            [z.bigint().min(5n), 3n, '5以上の数値である必要があります'],
+            [z.array(z.string()).min(2), ['a'], '2個以上の要素が必要です'],
+            [z.array(z.string()).length(3), ['a'], '3個の要素が必要です'],
+            [z.set(z.string()).min(2), new Set(['a']), '入力形式が間違っています']
+        ])('schema=%o, input=%o → %s', (schema, input, expected) => {
+            expect(msg(schema, input)).toBe(expected);
+        });
+
+        it('number exact', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_small, minimum: 5, inclusive: true, exact: true, type: 'number', path: [], message: '' },
+                { data: 3, defaultError: '' }
+            );
+            expect(result.message).toBe('5の数値である必要があります');
+        });
+
+        it('array not_inclusive', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_small, minimum: 2, inclusive: false, type: 'array', path: [], message: '' },
+                { data: [1], defaultError: '' }
+            );
+            expect(result.message).toBe('2個より多くの要素が必要です');
+        });
+
+        it('date inclusive', () => {
+            const minDate = new Date('2024-01-01T00:00:00Z');
+            const schema = z.date().min(minDate);
+            expect(msg(schema, new Date('2023-01-01'))).toMatch(/以降の日時である必要があります$/);
+        });
+
+        it('date exact', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_small, minimum: new Date('2024-01-01').getTime(), inclusive: true, exact: true, type: 'date', path: [], message: '' },
+                { data: null, defaultError: '' }
+            );
+            expect(result.message).toMatch(/の日時である必要があります$/);
+        });
+
+        it('date not_inclusive', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_small, minimum: new Date('2024-01-01').getTime(), inclusive: false, type: 'date', path: [], message: '' },
+                { data: null, defaultError: '' }
+            );
+            expect(result.message).toMatch(/よりも後の日時である必要があります$/);
+        });
+
+        it('string not_inclusive', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_small, minimum: 3, inclusive: false, type: 'string', path: [], message: '' },
+                { data: 'ab', defaultError: '' }
+            );
+            expect(result.message).toBe('3文字より長い文字列である必要があります');
+        });
+
+        it('bigint exact', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_small, minimum: 5, inclusive: true, exact: true, type: 'bigint', path: [], message: '' },
+                { data: 3n, defaultError: '' }
+            );
+            expect(result.message).toBe('5の数値である必要があります');
+        });
+
+        it('bigint not_inclusive', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_small, minimum: 5, inclusive: false, type: 'bigint', path: [], message: '' },
+                { data: 3n, defaultError: '' }
+            );
+            expect(result.message).toBe('5より大きな数値である必要があります');
+        });
+    });
+
+    describe('too_big', () => {
+        it.each([
+            [z.string().max(2), 'abcd', '2文字以下の文字列である必要があります'],
+            [z.string().length(2), 'abcd', '2文字の文字列である必要があります'],
+            [z.number().lte(5), 10, '5以下の数値である必要があります'],
+            [z.number().lt(5), 5, '5より小さな数値である必要があります'],
+            [z.bigint().max(5n), 10n, '5以下の数値である必要があります'],
+            [z.array(z.string()).max(1), ['a', 'b'], '1個以下の要素である必要があります'],
+            [z.array(z.string()).length(1), ['a', 'b'], '1個の要素である必要があります'],
+            [z.set(z.string()).max(1), new Set(['a', 'b']), '入力形式が間違っています']
+        ])('schema=%o, input=%o → %s', (schema, input, expected) => {
+            expect(msg(schema, input)).toBe(expected);
+        });
+
+        it('string not_inclusive', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_big, maximum: 3, inclusive: false, type: 'string', path: [], message: '' },
+                { data: 'abcd', defaultError: '' }
+            );
+            expect(result.message).toBe('3文字より短い文字列である必要があります');
+        });
+
+        it('number exact', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_big, maximum: 5, inclusive: true, exact: true, type: 'number', path: [], message: '' },
+                { data: 10, defaultError: '' }
+            );
+            expect(result.message).toBe('5の数値である必要があります');
+        });
+
+        it('array not_inclusive', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_big, maximum: 2, inclusive: false, type: 'array', path: [], message: '' },
+                { data: [1, 2, 3], defaultError: '' }
+            );
+            expect(result.message).toBe('2個より少ない要素である必要があります');
+        });
+
+        it('date inclusive', () => {
+            const maxDate = new Date('2024-01-01T00:00:00Z');
+            const schema = z.date().max(maxDate);
+            expect(msg(schema, new Date('2025-01-01'))).toMatch(/以前の日時である必要があります$/);
+        });
+
+        it('date exact', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_big, maximum: new Date('2024-01-01').getTime(), inclusive: true, exact: true, type: 'date', path: [], message: '' },
+                { data: null, defaultError: '' }
+            );
+            expect(result.message).toMatch(/の日時である必要があります$/);
+        });
+
+        it('date not_inclusive', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_big, maximum: new Date('2024-01-01').getTime(), inclusive: false, type: 'date', path: [], message: '' },
+                { data: null, defaultError: '' }
+            );
+            expect(result.message).toMatch(/よりも前の日時である必要があります$/);
+        });
+
+        it('bigint exact', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_big, maximum: 5, inclusive: true, exact: true, type: 'bigint', path: [], message: '' },
+                { data: 10n, defaultError: '' }
+            );
+            expect(result.message).toBe('5の数値である必要があります');
+        });
+
+        it('bigint not_inclusive', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.too_big, maximum: 5, inclusive: false, type: 'bigint', path: [], message: '' },
+                { data: 10n, defaultError: '' }
+            );
+            expect(result.message).toBe('5より小さな数値である必要があります');
+        });
+    });
+
+    describe('custom', () => {
+        it('refine 失敗', () => {
+            const schema = z.string().refine(() => false);
+            expect(msg(schema, 'hello')).toBe('入力形式が間違っています');
+        });
+    });
+
+    describe('not_multiple_of', () => {
+        it('倍数チェック', () => {
+            const schema = z.number().multipleOf(3);
+            expect(msg(schema, 7)).toBe('3の倍数である必要があります');
+        });
+    });
+
+    describe('not_finite', () => {
+        it('有限数チェック', () => {
+            const schema = z.number().finite();
+            expect(msg(schema, Infinity)).toBe('有限数である必要があります');
+        });
+    });
+
+    describe('jaErrorMap 直接呼び出し', () => {
+        it('invalid_arguments', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.invalid_arguments, argumentsError: new z.ZodError([]), path: [], message: '' },
+                { data: null, defaultError: '' }
+            );
+            expect(result.message).toBe('引数が間違っています');
+        });
+
+        it('invalid_return_type', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.invalid_return_type, returnTypeError: new z.ZodError([]), path: [], message: '' },
+                { data: null, defaultError: '' }
+            );
+            expect(result.message).toBe('返値の型が間違っています');
+        });
+
+        it('invalid_intersection_types', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.invalid_intersection_types, path: [], message: '' },
+                { data: null, defaultError: '' }
+            );
+            expect(result.message).toBe('交差型のマージができませんでした');
+        });
+
+        it('invalid_type で未知の型ラベルはそのまま出力される', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.invalid_type, expected: 'custom_type' as z.ZodParsedType, received: 'custom_received' as z.ZodParsedType, path: [], message: '' },
+                { data: 42, defaultError: '' }
+            );
+            expect(result.message).toBe('custom_typeでの入力を期待していますが、custom_receivedが入力されました');
+        });
+
+        it('invalid_string で未知のオブジェクト validation はフォールバック', () => {
+            const result = jaErrorMap(
+                { code: z.ZodIssueCode.invalid_string, validation: { unknown: true } as never, path: [], message: '' },
+                { data: 'test', defaultError: '' }
+            );
+            expect(result.message).toBe('入力形式が間違っています');
+        });
+
+        it('未知のコードは defaultError を返す', () => {
+            const result = jaErrorMap(
+                { code: 'unknown_code', path: [], message: '' } as unknown as z.ZodIssueOptionalMessage,
+                { data: null, defaultError: 'fallback' }
+            );
+            expect(result.message).toBe('fallback');
+        });
     });
 });


### PR DESCRIPTION
## Summary

- `initValidate()` が呼び出しごとに `i18next.init()` を実行し、SSR の per-request 呼び出しで数 MB/req のメモリリークを起こし得る問題を修正
- `i18next` / `zod-i18n-map` を `peerDependencies` および playground 各環境から撤去し、自前の日本語 `ZodErrorMap` (`jaErrorMap`) に完全置換
- 再呼び出しガード（`initialized` フラグ）を追加し、複数回呼び出し時の安全性を確保
- `JSON.stringify(issue.expected)` による bigint リテラルクラッシュを `String()` で修正
- テストを 63 ケースに拡充（全ブランチカバレッジ 100%）

closes #799

## Test plan

- [x] `pnpm test:run` — 全 673 テスト通過
- [x] `pnpm type-check` — 型チェック通過
- [x] `pnpm lint:fix` — lint クリア
- [x] `pnpm build` — ビルド成功
- [x] `pnpm vitest run --coverage src/test/plugins/init-validate.spec.ts` — カバレッジ 100%

Generated with [Claude Code](https://claude.ai/code)