### PR TITLE
fix(css): move scrollbar-gutter: stable to html element

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -15,14 +15,14 @@
     }
     :where(html) {
         box-sizing: border-box;
-        scrollbar-gutter: auto;
+        scrollbar-gutter: stable;
         font-size: 62.5%; /* 1rem = 10px */
         scroll-behavior: smooth;
     }
     body {
         min-height: var(--height-vh);
         overflow-y: auto;
-        scrollbar-gutter: stable;
+        scrollbar-gutter: auto;
         font-family: var(--font-sans);
         font-size: var(--font-size-medium);
         font-feature-settings: 'palt';


### PR DESCRIPTION
## Summary

- `scrollbar-gutter: stable` を `body` から実スクロール対象の `html` に移動
- スクロールロック（`overflow: hidden`）時のレイアウトシフトを構造的に解消

## Test plan

- [x] ビルド成功確認
- [x] lint / typecheck パス
- [x] playground（Vue）で PC / SP 表示確認 — 崩れなし
- [x] モーダル・ドロワー表示時にレイアウトシフトなし確認
- [x] コンソールエラー・警告なし

Closes #807

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>