### PR TITLE
ci(dependabot): extend auto-merge to include minor updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-name: Dependabot patch ver auto-merge
+name: Dependabot auto-merge
 on: pull_request
 
 permissions:
@@ -18,7 +18,10 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
-        run: gh pr merge --auto --merge
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- Dependabot の auto-merge 対象を patch のみから **patch + minor** に拡張
- major 更新は引き続き手動対応

## Test plan
- [x] Dependabot が minor update の PR を作成した際に auto-merge が有効になることを確認

Generated with [Claude Code](https://claude.ai/code)