### PR TITLE
ci(dependabot): devDependencies以外は自動マージ対象から除外

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,8 +19,10 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Enable auto-merge for Dependabot PRs
         if: >-
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          (steps.metadata.outputs.package-ecosystem == 'github-actions' ||
+           steps.metadata.outputs.dependency-type == 'direct:development') &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,15 @@ playground 共通スタイルは `playground/shared/styles/playground.css`、vee
 - playground に該当コンポーネントのサンプルがまだ存在しない場合は `shared/pages/` に追加する
 - Nuxt 3 / Nuxt 4 固有の問題（SSR フラッシュ・ハイドレーションエラー等）が確認できた場合は対処する
 
+## CI / Dependabot
+
+`.github/workflows/dependabot-auto-merge.yml` の自動マージ対象は以下に限定している。
+
+- GitHub Actions の minor/patch 更新
+- npm の **devDependencies** の minor/patch 更新
+
+`dependencies` / `peerDependencies`（vue, zod, lucide-vue-next 等）は本ライブラリの利用側プロジェクトに直接影響するため、minor 更新であっても自動マージの対象外とし、手動レビューを必須とする。`update-type` だけで判定すると production 系の依存も自動マージされてしまうため、`dependabot/fetch-metadata` の `dependency-type` 出力（`direct:development` かどうか）と `package-ecosystem` 出力を併用して判定すること。
+
 ## 禁止事項
 
 - `develop` `main`ブランチでの作業は禁止


### PR DESCRIPTION
## Summary
- このライブラリは利用側プロジェクトに `dependencies` / `peerDependencies`（vue, zod, lucide-vue-next 等）が直接影響するため、production系の minor 更新まで自動マージしていたのは利用側への影響リスクがあった
- 自動マージ対象を「GitHub Actions の minor/patch」「npm devDependencies の minor/patch」のみに限定し、production/peerDependencies および indirect 依存の更新は手動レビューに回すよう変更

## Test plan
- [x] `dependabot/fetch-metadata` の `dependency-type` 出力値（`direct:production` / `direct:development` / `indirect`）を実際の過去PRラベル（`deps` / `deps-dev` プレフィックス）から確認し、peerDependencies が `direct:production` に分類されることを確認
- [x] YAML構文を Ruby の YAML パーサーで検証
- [ ] 次回 dependabot PR 発生時に実際の自動マージ挙動を確認

Generated with [Claude Code](https://claude.ai/code)