### PR TITLE
ci(dependabot): cooldown明け後の自動リベースで auto-merge を再発火

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -1,0 +1,26 @@
+name: Dependabot rebase
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Rebase open Dependabot PRs
+        run: |
+          prs=$(gh pr list --author "dependabot[bot]" --state open --json number --jq '.[].number')
+          for pr in $prs; do
+            echo "Rebasing PR #$pr..."
+            gh pr comment "$pr" --body "@dependabot rebase"
+            sleep 5
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Rebase open Dependabot PRs
         run: |
-          prs=$(gh pr list --author "dependabot[bot]" --state open --json number --jq '.[].number')
+          prs=$(gh pr list --author "dependabot[bot]" --state open --limit 100 --json number --jq '.[].number')
           for pr in $prs; do
             echo "Rebasing PR #$pr..."
             gh pr comment "$pr" --body "@dependabot rebase"


### PR DESCRIPTION
## 概要

`dependabot.yml` に設定済みの `cooldown: default-days: 7` により、クールダウンのタイミングと実際のPR作成タイミングのズレ等で `dependabot-auto-merge.yml` の `pull_request` イベントが正しく再評価されず、open のまま放置されるケースへの安全ネットです。

- 毎週月曜 00:00 UTC（JST 09:00）に open な Dependabot PR を列挙
- 各 PR に `@dependabot rebase` をコメント
- Dependabot のリベースで `pull_request: synchronize` イベントが発火し、既存の `dependabot-auto-merge.yml` が再評価される

### なぜ `@dependabot rebase` 経由か

- 既存ワークフローの auto-merge 条件判定（ecosystem / dependency-type / update-type）をそのまま再利用できる
- schedule トリガーでは `dependabot/fetch-metadata` が使えないため、`gh pr merge --auto` を直接叩く場合は条件判定を別途実装する必要がある（二重管理を避けた）

### 動作確認

- GITHUB_TOKEN の権限について: Dependabot がトリガーした `pull_request` イベントは既定で read-only token になりますが、`dependabot-auto-merge.yml` はジョブレベルで `permissions: pull-requests: write, contents: write` を明示しており、これは公式ドキュメント記載の正規の回避策です。本PRのリベース経由の synchronize イベントでも同様にこの権限上書きが適用されるため、既存の自動マージ処理は問題なく再発火します
- YAML構文を `ruby -ryaml` で検証済み
- `gh pr list` のデフォルト件数上限（30件）を回避するため `--limit 100` を明示

### 既知のリスク

- 毎週 open な Dependabot PR を一律でリベース対象にするため、auto-merge 対象外（major更新など）の意図的に open にしているPRも対象になります。ブランチ保護で「新しいコミットpush時に既存レビューを無効化」設定がある場合、承認済みレビューが無効化される可能性があります

## Test plan

- [ ] develop へマージ後、`workflow_dispatch` を一時追加して手動実行 or 次の月曜の自動実行を待つ
- [ ] open な Dependabot PR に `@dependabot rebase` コメントが付くことを確認
- [ ] リベース後に `dependabot-auto-merge.yml` が synchronize で再実行されることを確認

Generated with [Claude Code](https://claude.ai/code)