### PR TITLE
ci: Dependabot rebase後にCIを再トリガーするワークフローを追加

### DIFF
--- a/.github/workflows/dependabot-retrigger-ci.yml
+++ b/.github/workflows/dependabot-retrigger-ci.yml
@@ -1,0 +1,18 @@
+name: Re-trigger CI for Dependabot rebase
+on:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  retrigger:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close and reopen PR to trigger CI
+        env:
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMATION_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr close "$PR_NUMBER" -R "$GITHUB_REPOSITORY"
+          sleep 3
+          gh pr reopen "$PR_NUMBER" -R "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary
- Dependabot PRに `@dependabot rebase` を実行した際、GitHubの無限ループ防止機構により CI が実行されない問題を修正
- `pull_request_target: synchronize` をトリガーに、PATでPRをclose→reopenして `pull_request: reopened` イベント経由でCIを再トリガーする

## 前提
- `DEPENDABOT_AUTOMATION_TOKEN`（Fine-grained PAT）をDependabot secretsに登録が必要

## Test plan
- [x] Dependabot PRに `@dependabot rebase` を実行
- [x] Actionsタブで `Re-trigger CI for Dependabot rebase` ワークフローが実行されることを確認
- [x] close/reopen後にCIワークフローが実行されることを確認

Generated with [Claude Code](https://claude.ai/code)