### PR TITLE
Fix Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,13 +1,14 @@
 name: Dependabot auto-merge
-on: pull_request
+on: pull_request_target
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     permissions:
       pull-requests: write
       contents: write
@@ -17,12 +18,18 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
-      - name: Enable auto-merge for Dependabot PRs
+      - name: Show Dependabot metadata
+        run: |
+          echo "package-ecosystem=${{ steps.metadata.outputs.package-ecosystem }}"
+          echo "dependency-type=${{ steps.metadata.outputs.dependency-type }}"
+          echo "update-type=${{ steps.metadata.outputs.update-type }}"
+      - name: Enable auto-merge Dependabot PRs
         if: >-
-          (steps.metadata.outputs.package-ecosystem == 'github-actions' ||
-           steps.metadata.outputs.dependency-type == 'direct:development') &&
+          ((steps.metadata.outputs.package-ecosystem == 'github-actions' ||
+          steps.metadata.outputs.package-ecosystem == 'github_actions') ||
+          steps.metadata.outputs.dependency-type == 'direct:development') &&
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+          steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch Dependabot auto-merge workflow to `pull_request_target` so the job can enable auto-merge with write permissions.
- Accept both `github-actions` and `github_actions` metadata values for GitHub Actions updates.
- Log Dependabot metadata outputs to make skipped auto-merge conditions diagnosable.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dependabot-auto-merge.yml"); puts "yaml ok"'`
- `git diff --check -- .github/workflows/dependabot-auto-merge.yml`