### PR TITLE
Reduce Dependabot lockfile contention

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,11 @@ updates:
       - '/playground/nuxt4'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 7
     groups:
-      npm-dependencies:
-        group-by: 'dependency-name'
+      npm-minor-patch:
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
## Summary
- Limit npm Dependabot version update PRs to one open PR at a time.
- Group npm minor and patch updates into a single Dependabot PR.
- This reduces concurrent edits to `pnpm-lock.yaml` after auto-merge.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "yaml ok"'`
- `git diff --check -- .github/dependabot.yml`