### PR TITLE
TabとStepのアクティブ色をbrandに揃える

### DIFF
--- a/src/components/navigation/Step.vue
+++ b/src/components/navigation/Step.vue
@@ -189,6 +189,10 @@ const hasSlot = (name: string) => {
                 transition: transform 0.2s;
             }
             &.is-current {
+                color: var(--color-status-brand);
+                .icon {
+                    background-color: var(--color-status-brand);
+                }
                 .text {
                     transform: scale(1);
                 }

--- a/src/components/navigation/Tab.vue
+++ b/src/components/navigation/Tab.vue
@@ -111,6 +111,7 @@ defineExpose({ tabAlignProperty, tabButtonRef, currentTabClientRects });
                 :data-tab-button="tab.id"
                 :size="size"
                 shape="skeleton"
+                :class="{ 'is-current': currentTab === tab.id }"
                 :readonly="currentTab === tab.id"
                 v-for="tab in tabs"
                 :key="tab.id"
@@ -147,6 +148,9 @@ defineExpose({ tabAlignProperty, tabButtonRef, currentTabClientRects });
         :deep(.component-button) {
             height: var(--c-tab-button-height);
             padding: 0 1em;
+        }
+        :deep(.component-button.is-current) {
+            color: var(--color-status-brand);
         }
         .active-border {
             position: absolute;


### PR DESCRIPTION
## 概要
- Tabのアクティブなボタン文字色をbrandカラーに変更
- Stepの現在ステップの文字色とアイコン背景色をbrandカラーに変更

## 確認
- pnpm lint:fix
- pnpm type-check
- Vue playgroundのNavigationページでPC/SP表示をPlaywright CLI確認
- Storybookをworktree側で起動して確認用URLを提供