### PR TITLE
playgroundのNavigation表示とStep動作を修正

### DIFF
--- a/playground/shared/pages/NavigationPage.vue
+++ b/playground/shared/pages/NavigationPage.vue
@@ -34,53 +34,65 @@ const bottomNavItems = [
 <template>
     <div>
         <section class="pg-section">
-            <h2>Breadcrumb</h2>
+            <div class="pg-section-heading">
+                <h2>Breadcrumb</h2>
+                <p>現在位置を示す基本的なパンくずリストです。</p>
+            </div>
             <MiBreadcrumb :items="breadcrumbItems" />
         </section>
 
         <section class="pg-section">
-            <h2>Tab</h2>
-            <MiTab v-model="currentTab" :tabs="tabs" style="height: 160px;">
+            <div class="pg-section-heading">
+                <h2>Tab</h2>
+                <p>同じ文脈内で表示内容を切り替えます。</p>
+            </div>
+            <MiTab v-model="currentTab" :tabs="tabs" class="pg-navigation-tab">
                 <template #tab1>
-                    <div style="padding: 16px;">タブ 1 のコンテンツ</div>
+                    <div class="pg-navigation-panel">タブ 1 のコンテンツ</div>
                 </template>
                 <template #tab2>
-                    <div style="padding: 16px;">タブ 2 のコンテンツ</div>
+                    <div class="pg-navigation-panel">タブ 2 のコンテンツ</div>
                 </template>
                 <template #tab3>
-                    <div style="padding: 16px;">タブ 3 のコンテンツ</div>
+                    <div class="pg-navigation-panel">タブ 3 のコンテンツ</div>
                 </template>
             </MiTab>
         </section>
 
         <section class="pg-section">
-            <h2>Step</h2>
+            <div class="pg-section-heading">
+                <h2>Step</h2>
+                <p>入力、確認、完了のような順序付きフローを進めます。</p>
+            </div>
             <MiStep v-model="currentStep" :steps="steps">
                 <template #step1>
-                    <div style="padding: 16px;">ステップ 1: 情報を入力してください</div>
+                    <div class="pg-navigation-panel">ステップ 1: 情報を入力してください</div>
                 </template>
                 <template #step2>
-                    <div style="padding: 16px;">ステップ 2: 内容を確認してください</div>
+                    <div class="pg-navigation-panel">ステップ 2: 内容を確認してください</div>
                 </template>
                 <template #step3>
-                    <div style="padding: 16px;">ステップ 3: 完了しました！</div>
+                    <div class="pg-navigation-panel">ステップ 3: 完了しました！</div>
                 </template>
             </MiStep>
         </section>
 
         <section class="pg-section">
-            <h2>Pagination</h2>
-            <div class="pg-row" style="flex-direction: column;">
+            <div class="pg-section-heading">
+                <h2>Pagination</h2>
+                <p>ページングが必要な一覧で現在ページを切り替えます。</p>
+            </div>
+            <div class="pg-row pg-row-column">
                 <MiPagination v-model="currentPage" :total="20" />
-                <span>現在のページ: {{ currentPage }}</span>
+                <span class="pg-muted">現在のページ: {{ currentPage }}</span>
             </div>
         </section>
 
         <section class="pg-section">
-            <h2>BottomNav（プレビュー）</h2>
-            <p style=" margin-bottom: 12px;font-size: 0.85rem; color: var(--color-theme-text-secondary);">
-                ※ 通常は画面下部に固定表示されます。ここでは no-shadow で表示しています。
-            </p>
+            <div class="pg-section-heading">
+                <h2>BottomNav</h2>
+                <p>通常は画面下部に固定表示されます。ここでは no-shadow で表示しています。</p>
+            </div>
             <MiBottomNav :items="bottomNavItems" no-shadow />
         </section>
     </div>

--- a/playground/shared/styles/playground.css
+++ b/playground/shared/styles/playground.css
@@ -1,7 +1,21 @@
 body {
-    font-family: sans-serif;
+    font-family:
+        Roboto,
+        'Noto Sans JP',
+        '游ゴシック Medium',
+        'Yu Gothic Medium',
+        '游ゴシック体',
+        yugothic,
+        'Yu Gothic',
+        'Hiragino Kaku Gothic Pro',
+        'ヒラギノ角ゴ Pro',
+        meiryo,
+        'メイリオ',
+        sans-serif;
+    font-size: var(--font-size-medium);
+    line-height: 1.5;
     color: var(--color-theme-text-primary);
-    letter-spacing: 0;
+    letter-spacing: 0.05em;
     background-color: var(--color-theme-bg-primary);
     transition: background-color 0.2s, color 0.2s;
 }
@@ -14,27 +28,29 @@ body {
 
 .pg-header {
     display: flex;
-    gap: 24px;
+    flex-wrap: wrap;
+    gap: 16px 24px;
     align-items: center;
-    padding: 12px 24px;
+    padding: 16px 24px;
     background-color: var(--color-theme-bg-secondary);
     border-bottom: 1px solid var(--color-theme-border);
 }
 
 .pg-header-title {
     margin-right: auto;
-    font-size: 1.1rem;
+    font-size: var(--font-size-large);
     font-weight: bold;
 }
 
 .pg-nav {
     display: flex;
+    flex-wrap: wrap;
     gap: 8px;
 }
 
 .pg-nav a {
-    padding: 4px 12px;
-    font-size: 0.9rem;
+    padding: 8px 12px;
+    font-size: var(--font-size-medium);
     color: var(--color-theme-text-primary);
     text-decoration: none;
     border-radius: 4px;
@@ -47,8 +63,8 @@ body {
 
 .pg-main {
     width: 100%;
-    max-width: 960px;
-    padding: 24px;
+    max-width: 1040px;
+    padding: 32px 24px 40px;
     margin: 0 auto;
 }
 
@@ -56,12 +72,22 @@ body {
     margin-bottom: 40px;
 }
 
+.pg-section-heading {
+    margin-bottom: 16px;
+}
+
+.pg-section-heading h2,
 .pg-section h2 {
     padding-bottom: 8px;
-    margin-bottom: 16px;
-    font-size: 1rem;
+    margin: 0 0 8px;
+    font-size: var(--font-size-large);
     font-weight: bold;
     border-bottom: 1px solid var(--color-theme-border);
+}
+
+.pg-section-heading p {
+    margin: 0;
+    color: var(--color-theme-text-secondary);
 }
 
 .pg-row {
@@ -71,15 +97,31 @@ body {
     align-items: flex-start;
 }
 
+.pg-row-column {
+    flex-direction: column;
+}
+
+.pg-muted {
+    color: var(--color-theme-text-secondary);
+}
+
+.pg-navigation-tab {
+    min-height: 180px;
+}
+
+.pg-navigation-panel {
+    padding: 16px;
+}
+
 .pg-override-desc {
     margin-bottom: 16px;
-    font-size: 0.9rem;
+    font-size: var(--font-size-medium);
 }
 
 .pg-override-desc code,
 .pg-override-label code {
     padding: 2px 6px;
-    font-size: 0.85rem;
+    font-size: var(--font-size-medium);
     background-color: var(--color-theme-bg-secondary);
     border-radius: 4px;
 }
@@ -104,7 +146,7 @@ body {
 
 .pg-override-card h3 {
     margin-bottom: 8px;
-    font-size: 0.85rem;
+    font-size: var(--font-size-medium);
     font-weight: bold;
     color: var(--color-theme-text-secondary, #888);
 }
@@ -124,7 +166,7 @@ body {
 
 .pg-override-sample {
     padding: 12px;
-    font-size: 1.1rem;
+    font-size: var(--font-size-medium);
     background-color: var(--color-theme-bg-secondary);
     border-radius: 4px;
 }

--- a/src/components/navigation/Step.vue
+++ b/src/components/navigation/Step.vue
@@ -59,6 +59,7 @@ const onChangeTab = (id: string) => {
     transitionFrom.value = ['top', 'bottom'].includes(props.position)
         ? transitionFromX
         : transitionFromY;
+    currentStep.value = id;
 
     if (isPrev) {
         emit('prev', id);

--- a/src/test/components/navigation/Step.spec.ts
+++ b/src/test/components/navigation/Step.spec.ts
@@ -149,4 +149,27 @@ describe('Step', () => {
         await buttons[0].trigger('click');
         expect(wrapper.emitted('prev')).toBeTruthy();
     });
+
+    it('Next ボタンをクリックすると v-model が次の step に更新される', async () => {
+        const wrapper = mount(Step, {
+            props: {
+                steps,
+                modelValue: 'step1',
+                'onUpdate:modelValue': (v: string | undefined) =>
+                    wrapper.setProps({ modelValue: v })
+            },
+            slots: {
+                step1: '<div>入力</div>',
+                step2: '<div>確認</div>',
+                step3: '<div>完了</div>'
+            }
+        });
+
+        const footerButtons = wrapper.findAll('.step-footer button');
+        await footerButtons[1].trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.props('modelValue')).toBe('step2');
+        expect(wrapper.findAll('.step-button')[1].classes()).toContain('is-current');
+    });
 });


### PR DESCRIPTION
## 概要
- MiStep が v-model 単独でステップ更新できるように修正
- Navigation playground の Step / Tab などの表示サンプルを整理
- playground 全体と Style Override セクションの文字サイズを DESIGN.md 基準へ調整
- Step の Next 操作に対する回帰テストを追加

## レビュー
- review skill の手順に従い、現在の差分を手動レビュー
- PR作成を止める不具合は見つかりませんでした

## 確認
- pnpm lint:fix（実行済み。ただし stylelint --fix が Vue ファイルを破損させるため、最終状態は修復後に fixer なし lint で確認）
- pnpm exec eslint playground/shared/pages/NavigationPage.vue src/components/navigation/Step.vue src/test/components/navigation/Step.spec.ts
- pnpm exec stylelint playground/shared/styles/playground.css src/components/navigation/Step.vue
- pnpm type-check
- pnpm exec vitest run src/test/components/navigation/Step.spec.ts
- pnpm build
- Playwright CLI で Vue / Nuxt4 playground の PC・SP 表示、Step操作、コンソールを確認

## 補足
- pnpm build では既存の vite-plugin-dts による src/nuxt/module.ts の import.meta 警告が表示されますが、コマンドは正常終了しています。
- Nuxt4 playground 起動時に既存の @pinia/nuxt 互換警告と @unhead/vue import 警告が表示されます。