### PR TITLE
Dependabotのvitest/storybookエコシステムをグループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,15 @@ updates:
     cooldown:
       default-days: 7
     groups:
+      vitest-ecosystem:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+      storybook-ecosystem:
+        patterns:
+          - 'storybook'
+          - '@storybook/*'
+          - 'eslint-plugin-storybook'
       npm-minor-patch:
         update-types:
           - 'minor'


### PR DESCRIPTION
## 背景

payload リポジトリで `@payloadcms/next` だけが Dependabot により先行自動マージされ、`payload` 本体・他の `@payloadcms/*` パッケージとバージョン不整合を起こしログイン不能になった事象があった（[furutsubaki/payload#92](https://github.com/furutsubaki/payload/pull/92)）。

これを踏まえ、minazuki-ui にも同種の「エコシステム内パッケージが個別 PR で部分アップデートされバージョン不整合を起こすリスク」がないか確認した。

## 確認結果

- `@vitest/coverage-v8` / `@vitest/coverage-istanbul` は、pnpm-lock.yaml 上で `vitest` に対し **exact な peerDependency**（`vitest: 3.2.4`）を要求している。package.json 側は3パッケージとも `"3"`（`^3.0.0` 相当のゆるい範囲）のため、Dependabot が `vitest` のみを先行更新すると payload と同様の不整合が起こり得る。
- Storybook 系（`storybook` / `@storybook/vue3` / `@storybook/vue3-vite` / `@storybook/addon-docs` / `eslint-plugin-storybook`）は peerDependency 自体はゆるい範囲（`^10.3.6`）だが、アップストリームで同時リリース・バージョン同期が前提のエコシステムであり、package.json 側もすべて exact pin 済みのため、防御的にグループ化する。
- 現時点では lockfile 上すでにバージョンが揃っており、実際の不整合は発生していない（package.json のバージョン修正は不要、Dependabot 設定のみ対応）。
- 併せて shigurezuki リポジトリも同様の観点で確認したが、`nuxt` 以外に exact peerDependency で連鎖するパッケージはなく対応不要と判断。

## 変更内容

`.github/dependabot.yml` の npm セクションに `vitest-ecosystem` / `storybook-ecosystem` グループを追加し、既存の `npm-minor-patch` より先に評価されるようにした。

## 検証

- `ruby -ryaml -e "YAML.load_file(...)"` で YAML 構文を確認済み
