### PR TITLE
developのビルド失敗を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "eslint-plugin-vue": "^10.9.1",
     "happy-dom": "^20.9.0",
     "husky": "^9.1.7",
+    "jiti": "2.7.0",
     "lint-staged": "^15.2.2",
     "npm-run-all2": "^6.2.2",
     "postcss-nesting": "^13.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jiti:
+        specifier: 2.7.0
+        version: 2.7.0
       lint-staged:
         specifier: ^15.2.2
         version: 15.5.2

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,8 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "declaration": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "declarationDir": "./dist",
     "rootDir": "./src",
     "baseUrl": "./src",


### PR DESCRIPTION
## 概要
- build script が直接呼び出す jiti を devDependencies に明示追加
- vite-plugin-dts の宣言生成で import.meta を扱えるよう tsconfig.build.json に module 設定を追加

## 確認
- pnpm lint:fix
- pnpm type-check
- pnpm build