### PR TITLE
release PRをドラフト化する

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -33,8 +33,20 @@ jobs:
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/.github/Gemfile
           GIT_PR_RELEASE_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           GIT_PR_RELEASE_BRANCH_PRODUCTION: main
           GIT_PR_RELEASE_BRANCH_STAGING: develop
           GIT_PR_RELEASE_LABELS: release
           GIT_PR_RELEASE_TEMPLATE: '.github/.git-pr-release-template'
-        run: bundle exec git-pr-release --no-fetch || echo "Done."
+        run: |
+          bundle exec git-pr-release --no-fetch || echo "Done."
+
+          release_pr_number="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head develop --state open --json number --jq '.[0].number // empty')"
+          if [ -z "$release_pr_number" ]; then
+            exit 0
+          fi
+
+          is_draft="$(gh pr view "$release_pr_number" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')"
+          if [ "$is_draft" != "true" ]; then
+            gh pr ready "$release_pr_number" --repo "$GITHUB_REPOSITORY" --undo
+          fi


### PR DESCRIPTION
## 概要
- release PR 作成 workflow で git-pr-release 実行後に対象 PR を取得するように変更
- 対象 PR が draft でない場合は gh pr ready --undo で draft 化
- GitHub CLI 用に GitHub App token を GH_TOKEN として渡す

## 確認
- pnpm lint:fix
- pnpm type-check
- git diff --check

## 補足
- ローカル環境では gh / ruby / python3 の一部コマンドが終了コード 134 で落ちたため、workflow の実行確認は未実施