### PR TITLE
feat!: Button APIリデザイン — label prop + auto-icon

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -123,7 +123,7 @@ CSS 変数名: `--color-{status}[-suffix]`（例: `--color-brand`, `--color-dang
 
 | 状態 | 背景色 | テキスト色 | ボーダー色 |
 |------|--------|-----------|-----------|
-| Default（通常） | `-surface` or `(base)-alpha` | `(base)` | `(base)` |
+| Default（通常） | `-surface` or `(base)` | `(base)` | `(base)` or `-emphasis` |
 | Hover | `-alpha` | `(base)` | `-emphasis` |
 | Active / Press | `-emphasis` | `neutral-50` | `-strong` |
 | Focus | — | — | `-emphasis`（ring） |
@@ -131,7 +131,7 @@ CSS 変数名: `--color-{status}[-suffix]`（例: `--color-brand`, `--color-dang
 | Selected | `-alpha` | `(base)` | `(base)` |
 | 半透明背景 | `-surface-alpha` | `(base)` | `(base)` |
 
-> **Note**: ここでの `(base)` は suffix なし（`--color-{status}`）を指す。上記は推奨の組み合わせであり、コンポーネントの文脈に応じて調整して構わない
+> **Note**: ここでの `(base)` は suffix なし（`--color-{status}`）を指す。上記は推奨の組み合わせであり、コンポーネントの文脈に応じて調整して構わない。Button の塗りつぶし系バリアント（primary/info/success/warning/danger）は背景に `(base)` 不透明色、ボーダーに `-emphasis`（明度を下げた色）を使う。status バリアント（info/success/warning/danger）にはデフォルトでアイコンが自動付与され、brand カラーの上書きによってステータス間の色が衝突した場合でもアイコンの形状差で視覚的に区別できるようにしている
 
 `lightnessOffset` が 0 の status は `var(--mi-{hue}-{step})` への参照で実装される（Primitive 変更に自動追従）。Warning のみ offset 適用後の hex 値を直接出力する。
 
@@ -343,12 +343,32 @@ font-feature-settings: 'palt';
 | Medium | 32px | `--font-size-medium` |
 | Small | 24px | `--font-size-small` |
 
-**Primary バリアント**
+**API**
 
-- Background: `var(--color-brand-alpha)`
-- Text: `var(--mi-neutral-50)`
-- Border Color: `var(--color-brand)`
-- Hover: テキスト・ボーダーが brand、背景が transparent に反転
+- `label` prop: ボタンのテキストコンテンツ
+- `prefixIcon` / `suffixIcon` prop: テキスト前後のアイコン（Vue コンポーネント）。status バリアント（info/success/warning/danger）では `prefixIcon` 未指定時にデフォルトアイコンが自動付与される
+- icon-only ボタン（`label` なし）では `aria-label` 属性を必ず付与すること
+- 記号的な `label`（`≪`、`≫` 等）を使用する場合も `aria-label` で目的を補足すること
+
+**Status アイコン自動付与**
+
+| Variant | デフォルトアイコン |
+|---------|------------------|
+| info | `Info` |
+| success | `CheckCircle2` |
+| warning | `AlertTriangle` |
+| danger | `XOctagon` |
+
+`prefixIcon` を明示指定した場合はデフォルトアイコンをオーバーライドする。primary / secondary にはデフォルトアイコンは付与されない。
+
+brand カラーの上書き（`overrideTheme`）により任意の status 間で色が衝突し得るが、アイコンの形状差によって区別が維持される。
+
+**Primary / Info / Success / Warning / Danger バリアント（塗りつぶし）**
+
+- Background: `var(--color-{status})`（不透明）
+- Text: `var(--mi-neutral-50)`（warning のみ `var(--mi-neutral-800)`）
+- Border Color: `var(--color-{status}-emphasis)`（明度を下げた色）
+- Hover: テキスト・ボーダーが `{status}` 色、背景が transparent に反転
 
 **Secondary バリアント**
 
@@ -356,6 +376,11 @@ font-feature-settings: 'palt';
 - Text: `var(--color-text-primary)`
 - Border Color: `var(--color-border)`
 - Hover: brand カラーの背景付きに反転
+
+**Link / Skeleton シェイプ**
+
+- `shape="link"` / `shape="skeleton"` は variant に関わらず背景・ボーダーが常に transparent
+- `shape="link"` は variant に関わらずテキスト色が `var(--color-link)` 固定（hover は `var(--color-link-hover)`）。a タグ相当の見た目にするため
 
 ### Inputs (`MiField` / `FieldFrame`)
 

--- a/playground/nuxt3/app.vue
+++ b/playground/nuxt3/app.vue
@@ -20,9 +20,7 @@ const toggleTheme = () => {
                 <NuxtLink to="/feedback">Feedback</NuxtLink>
                 <NuxtLink to="/navigation">Navigation</NuxtLink>
             </nav>
-            <MiButton :variant="currentTheme === 'dark' ? 'primary' : 'secondary'" size="small" @click="toggleTheme">
-                {{ currentTheme === 'dark' ? 'Light' : 'Dark' }} Mode
-            </MiButton>
+            <MiButton :variant="currentTheme === 'dark' ? 'primary' : 'secondary'" size="small" :label="currentTheme === 'dark' ? 'Light Mode' : 'Dark Mode'" @click="toggleTheme" />
         </header>
 
         <main class="pg-main">

--- a/playground/nuxt4/app/app.vue
+++ b/playground/nuxt4/app/app.vue
@@ -20,9 +20,7 @@ const toggleTheme = () => {
                 <NuxtLink to="/feedback">Feedback</NuxtLink>
                 <NuxtLink to="/navigation">Navigation</NuxtLink>
             </nav>
-            <MiButton :variant="currentTheme === 'dark' ? 'primary' : 'secondary'" size="small" @click="toggleTheme">
-                {{ currentTheme === 'dark' ? 'Light' : 'Dark' }} Mode
-            </MiButton>
+            <MiButton :variant="currentTheme === 'dark' ? 'primary' : 'secondary'" size="small" :label="currentTheme === 'dark' ? 'Light Mode' : 'Dark Mode'" @click="toggleTheme" />
         </header>
 
         <main class="pg-main">

--- a/playground/shared/pages/FeedbackPage.vue
+++ b/playground/shared/pages/FeedbackPage.vue
@@ -29,38 +29,38 @@ const sendNotification = (variant: 'secondary' | 'success' | 'warning' | 'danger
                 <MiAlert text="Success アラートです。" variant="success" title="成功" />
                 <MiAlert text="Warning アラートです。" variant="warning" title="警告" />
                 <MiAlert text="Danger アラートです。" variant="danger" title="エラー" closeable v-model="showAlert" />
-                <MiButton v-if="!showAlert" size="small" @click="showAlert = true">アラートを再表示</MiButton>
+                <MiButton v-if="!showAlert" size="small" label="アラートを再表示" @click="showAlert = true" />
             </div>
         </section>
 
         <section class="pg-section">
             <h2>Notifications（通知）</h2>
             <div class="pg-row">
-                <MiButton @click="sendNotification('secondary')">通知（Secondary）</MiButton>
-                <MiButton variant="info" @click="sendNotification('info')">通知（Info）</MiButton>
-                <MiButton variant="success" @click="sendNotification('success')">通知（Success）</MiButton>
-                <MiButton variant="warning" @click="sendNotification('warning')">通知（Warning）</MiButton>
-                <MiButton variant="danger" @click="sendNotification('danger')">通知（Danger）</MiButton>
+                <MiButton label="通知（Secondary）" @click="sendNotification('secondary')" />
+                <MiButton variant="info" label="通知（Info）" @click="sendNotification('info')" />
+                <MiButton variant="success" label="通知（Success）" @click="sendNotification('success')" />
+                <MiButton variant="warning" label="通知（Warning）" @click="sendNotification('warning')" />
+                <MiButton variant="danger" label="通知（Danger）" @click="sendNotification('danger')" />
             </div>
         </section>
 
         <section class="pg-section">
             <h2>Dialog</h2>
-            <MiButton @click="showDialog = true">ダイアログを開く</MiButton>
+            <MiButton label="ダイアログを開く" @click="showDialog = true" />
             <MiDialog v-model="showDialog" title="確認ダイアログ" variant="warning">
                 <template #default>
                     <p>この操作を実行してよろしいですか？</p>
                 </template>
                 <template #footer>
-                    <MiButton @click="showDialog = false">キャンセル</MiButton>
-                    <MiButton variant="danger" @click="showDialog = false">実行</MiButton>
+                    <MiButton label="キャンセル" @click="showDialog = false" />
+                    <MiButton variant="danger" label="実行" @click="showDialog = false" />
                 </template>
             </MiDialog>
         </section>
 
         <section class="pg-section">
             <h2>Modal</h2>
-            <MiButton variant="primary" @click="showModal = true">モーダルを開く</MiButton>
+            <MiButton variant="primary" label="モーダルを開く" @click="showModal = true" />
             <MiModal v-model="showModal" title="モーダルタイトル" size="medium">
                 <p>モーダルの本文です。ここにコンテンツが入ります。</p>
                 <p style="margin-top: 8px;">2行目のコンテンツです。</p>
@@ -69,12 +69,12 @@ const sendNotification = (variant: 'secondary' | 'success' | 'warning' | 'danger
 
         <section class="pg-section">
             <h2>Drawer</h2>
-            <MiButton @click="showDrawer = true">ドロワーを開く</MiButton>
+            <MiButton label="ドロワーを開く" @click="showDrawer = true" />
             <MiDrawer v-model="showDrawer" title="ドロワーメニュー" position="left">
                 <div style="display: flex; flex-direction: column; gap: 8px; padding: 16px;">
-                    <MiButton shape="link">メニュー 1</MiButton>
-                    <MiButton shape="link">メニュー 2</MiButton>
-                    <MiButton shape="link">メニュー 3</MiButton>
+                    <MiButton shape="link" label="メニュー 1" />
+                    <MiButton shape="link" label="メニュー 2" />
+                    <MiButton shape="link" label="メニュー 3" />
                 </div>
             </MiDrawer>
         </section>

--- a/playground/shared/pages/FormsPage.vue
+++ b/playground/shared/pages/FormsPage.vue
@@ -104,12 +104,8 @@ const radioGroupItems = [
                     placeholder="https://example.com"
                 />
                 <div class="pg-row">
-                    <MiButton variant="primary" :disabled="!canSubmit" @click="onSubmit">
-                        送信
-                    </MiButton>
-                    <MiButton variant="secondary" @click="onReset">
-                        リセット
-                    </MiButton>
+                    <MiButton variant="primary" :disabled="!canSubmit" label="送信" @click="onSubmit" />
+                    <MiButton variant="secondary" label="リセット" @click="onReset" />
                 </div>
             </div>
         </section>

--- a/playground/shared/pages/HomePage.vue
+++ b/playground/shared/pages/HomePage.vue
@@ -57,12 +57,8 @@ const resetBrandOverride = () => {
                 に反映されていることの確認になります。
             </p>
             <div class="pg-row">
-                <MiButton variant="primary" :disabled="isBrandOverridden" @click="applyBrandOverride">
-                    Brand を Purple に上書き
-                </MiButton>
-                <MiButton variant="secondary" :disabled="!isBrandOverridden" @click="resetBrandOverride">
-                    デフォルト（Teal）に戻す
-                </MiButton>
+                <MiButton variant="primary" :disabled="isBrandOverridden" label="Brand を Purple に上書き" @click="applyBrandOverride" />
+                <MiButton variant="secondary" :disabled="!isBrandOverridden" label="デフォルト（Teal）に戻す" @click="resetBrandOverride" />
             </div>
             <p class="pg-override-desc">
                 なお Vue 環境は <code>app.use(MinazukiUi, {'{'} theme {'}'})</code>（warning を Lime
@@ -76,15 +72,15 @@ const resetBrandOverride = () => {
         <section class="pg-section">
             <h2>Button</h2>
             <div class="pg-row">
-                <MiButton variant="primary">Primary</MiButton>
-                <MiButton variant="secondary">Secondary</MiButton>
-                <MiButton variant="info">Info</MiButton>
-                <MiButton variant="success">Success</MiButton>
-                <MiButton variant="warning">Warning</MiButton>
-                <MiButton variant="danger">Danger</MiButton>
-                <MiButton variant="primary" shape="rounded">Rounded</MiButton>
-                <MiButton variant="primary" disabled>Disabled</MiButton>
-                <MiButton variant="primary" shape="link">Link</MiButton>
+                <MiButton variant="primary" label="Primary" />
+                <MiButton variant="secondary" label="Secondary" />
+                <MiButton variant="info" label="Info" />
+                <MiButton variant="success" label="Success" />
+                <MiButton variant="warning" label="Warning" />
+                <MiButton variant="danger" label="Danger" />
+                <MiButton variant="primary" shape="rounded" label="Rounded" />
+                <MiButton variant="primary" disabled label="Disabled" />
+                <MiButton variant="primary" shape="link" label="Link" />
             </div>
         </section>
 
@@ -102,9 +98,7 @@ const resetBrandOverride = () => {
             <h2>Badge</h2>
             <div class="pg-row">
                 <MiBadge content="3" variant="danger" :model-value="showBadge">
-                    <MiButton variant="secondary" @click="showBadge = !showBadge">
-                        {{ showBadge ? 'バッジ非表示' : 'バッジ表示' }}
-                    </MiButton>
+                    <MiButton variant="secondary" :label="showBadge ? 'バッジ非表示' : 'バッジ表示'" @click="showBadge = !showBadge" />
                 </MiBadge>
                 <MiBadge content="99" variant="primary" inline :model-value="true">
                     <span>インライン</span>
@@ -131,9 +125,9 @@ const resetBrandOverride = () => {
                 <MiProgress v-model="progress" variant="success" shape="slim-line" />
                 <MiProgress v-model="progress" variant="info" shape="circle" style="width: 80px;" />
                 <div class="pg-row">
-                    <MiButton size="small" @click="progress = Math.max(0, progress - 10)">-10</MiButton>
+                    <MiButton size="small" label="-10" @click="progress = Math.max(0, progress - 10)" />
                     <span>{{ progress }}%</span>
-                    <MiButton size="small" variant="primary" @click="progress = Math.min(100, progress + 10)">+10</MiButton>
+                    <MiButton size="small" variant="primary" label="+10" @click="progress = Math.min(100, progress + 10)" />
                 </div>
             </div>
         </section>

--- a/playground/vue/src/App.vue
+++ b/playground/vue/src/App.vue
@@ -22,9 +22,7 @@ const toggleTheme = () => {
                 <RouterLink to="/feedback">Feedback</RouterLink>
                 <RouterLink to="/navigation">Navigation</RouterLink>
             </nav>
-            <MiButton :variant="currentTheme === 'dark' ? 'primary' : 'secondary'" size="small" @click="toggleTheme">
-                {{ currentTheme === 'dark' ? 'Light' : 'Dark' }} Mode
-            </MiButton>
+            <MiButton :variant="currentTheme === 'dark' ? 'primary' : 'secondary'" size="small" :label="currentTheme === 'dark' ? 'Light Mode' : 'Dark Mode'" @click="toggleTheme" />
         </header>
 
         <main class="pg-main">

--- a/src/components/basic/Button.vue
+++ b/src/components/basic/Button.vue
@@ -1,12 +1,27 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { type Component, computed, markRaw, ref } from 'vue';
+import {
+    Info as IconInfo,
+    CheckCircle2 as IconCheckCircle2,
+    AlertTriangle as IconAlertTriangle,
+    XOctagon as IconXOctagon
+} from 'lucide-vue-next';
+
+type Variant = 'primary' | 'secondary' | 'info' | 'success' | 'warning' | 'danger';
+
+const STATUS_ICON_MAP: Partial<Record<Variant, Component>> = {
+    info: markRaw(IconInfo),
+    success: markRaw(IconCheckCircle2),
+    warning: markRaw(IconAlertTriangle),
+    danger: markRaw(IconXOctagon)
+};
 
 const props = withDefaults(
     defineProps<{
         /**
          * 表示色
          */
-        variant?: 'primary' | 'secondary' | 'info' | 'success' | 'warning' | 'danger';
+        variant?: Variant;
         /**
          * サイズ
          */
@@ -23,13 +38,28 @@ const props = withDefaults(
          * 無効か
          */
         disabled?: boolean;
+        /**
+         * テキスト前アイコン
+         */
+        prefixIcon?: Component;
+        /**
+         * テキスト後アイコン
+         */
+        suffixIcon?: Component;
+        /**
+         * ボタンラベル
+         */
+        label?: string;
     }>(),
     {
         variant: 'secondary',
         size: 'medium',
         shape: 'normal',
         readonly: false,
-        disabled: false
+        disabled: false,
+        prefixIcon: undefined,
+        suffixIcon: undefined,
+        label: undefined
     }
 );
 const emit = defineEmits<{
@@ -46,6 +76,16 @@ const onClick = () => {
     emit('click');
 };
 
+const resolvedPrefixIcon = computed(() => {
+    if (props.prefixIcon) return markRaw(props.prefixIcon);
+    return STATUS_ICON_MAP[props.variant] ?? null;
+});
+
+const resolvedSuffixIcon = computed(() => {
+    if (props.suffixIcon) return markRaw(props.suffixIcon);
+    return null;
+});
+
 const buttonRef = ref();
 defineExpose({ buttonRef });
 </script>
@@ -59,7 +99,9 @@ defineExpose({ buttonRef });
         :class="[variant, size, shape, { 'is-readonly': readonly }]"
         @click="onClick"
     >
-        <slot />
+        <component v-if="resolvedPrefixIcon" :is="resolvedPrefixIcon" class="button-icon" />
+        <span v-if="label" class="button-label">{{ label }}</span>
+        <component v-if="resolvedSuffixIcon" :is="resolvedSuffixIcon" class="button-icon" />
     </button>
 </template>
 
@@ -82,21 +124,10 @@ defineExpose({ buttonRef });
     transition:
         color 0.2s,
         background-color 0.2s,
-        border-color 0.2s,
-        opacity 0.2s,
-        filter 0.2s;
-    &.is-readonly {
-        pointer-events: none;
-    }
-    &:disabled {
-        pointer-events: none;
-        opacity: 0.5;
-        filter: grayscale(1);
-    }
+        border-color 0.2s;
 
-    /* hover */
     @media (hover: hover) {
-        &:hover {
+        &:hover:not(:disabled, .is-readonly) {
             color: var(--c-button-hover-color);
             background-color: var(--c-button-hover-background-color);
             border-color: var(--c-button-hover-border-color);
@@ -104,12 +135,23 @@ defineExpose({ buttonRef });
     }
 
     @media (hover: none) {
-        &:active {
+        &:active:not(:disabled, .is-readonly) {
             color: var(--c-button-hover-color);
             background-color: var(--c-button-hover-background-color);
             border-color: var(--c-button-hover-border-color);
         }
     }
+    &:disabled,
+    &.is-readonly {
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
+}
+
+.button-icon {
+    flex-shrink: 0;
+    width: 1em;
+    height: 1em;
 }
 
 /* ▼ variable ▼ */
@@ -119,8 +161,8 @@ defineExpose({ buttonRef });
     --c-button-hover-background-color: transparent;
     --c-button-hover-border-color: var(--color-brand);
     --c-button-color: var(--mi-neutral-50);
-    --c-button-background-color: var(--color-brand-alpha);
-    --c-button-border-color: var(--color-brand);
+    --c-button-background-color: var(--color-brand);
+    --c-button-border-color: var(--color-brand-emphasis);
 }
 
 .secondary {
@@ -136,9 +178,9 @@ defineExpose({ buttonRef });
     --c-button-hover-color: var(--color-info);
     --c-button-hover-background-color: transparent;
     --c-button-hover-border-color: var(--color-info);
-    --c-button-color: var(--color-text-primary);
-    --c-button-background-color: var(--color-info-alpha);
-    --c-button-border-color: var(--color-info);
+    --c-button-color: var(--mi-neutral-50);
+    --c-button-background-color: var(--color-info);
+    --c-button-border-color: var(--color-info-emphasis);
 }
 
 .success {
@@ -146,8 +188,8 @@ defineExpose({ buttonRef });
     --c-button-hover-background-color: transparent;
     --c-button-hover-border-color: var(--color-success);
     --c-button-color: var(--mi-neutral-50);
-    --c-button-background-color: var(--color-success-alpha);
-    --c-button-border-color: var(--color-success);
+    --c-button-background-color: var(--color-success);
+    --c-button-border-color: var(--color-success-emphasis);
 }
 
 .warning {
@@ -155,8 +197,8 @@ defineExpose({ buttonRef });
     --c-button-hover-background-color: transparent;
     --c-button-hover-border-color: var(--color-warning);
     --c-button-color: var(--mi-neutral-800);
-    --c-button-background-color: var(--color-warning-alpha);
-    --c-button-border-color: var(--color-warning);
+    --c-button-background-color: var(--color-warning);
+    --c-button-border-color: var(--color-warning-emphasis);
 }
 
 .danger {
@@ -164,8 +206,8 @@ defineExpose({ buttonRef });
     --c-button-hover-background-color: transparent;
     --c-button-hover-border-color: var(--color-danger);
     --c-button-color: var(--mi-neutral-50);
-    --c-button-background-color: var(--color-danger-alpha);
-    --c-button-border-color: var(--color-danger);
+    --c-button-background-color: var(--color-danger);
+    --c-button-border-color: var(--color-danger-emphasis);
 }
 
 /* ▲ variable ▲ */
@@ -206,7 +248,7 @@ defineExpose({ buttonRef });
     min-width: auto;
     word-break: keep-all;
     border-radius: 50%;
-    > :deep(.lucide) {
+    > .button-icon {
         width: 100%;
         height: 100%;
     }
@@ -218,13 +260,16 @@ defineExpose({ buttonRef });
     width: var(--c-button-height);
     min-width: auto;
     word-break: keep-all;
-    > :deep(.lucide) {
+    > .button-icon {
         width: 100%;
         height: 100%;
     }
 }
 
 .skeleton {
+    --c-button-background-color: transparent;
+    --c-button-border-color: transparent;
+
     min-width: initial;
     min-height: initial;
     padding: 0;
@@ -256,28 +301,19 @@ defineExpose({ buttonRef });
 }
 
 .link {
+    --c-button-color: var(--color-link);
+    --c-button-background-color: transparent;
+    --c-button-border-color: transparent;
+    --c-button-hover-color: var(--color-link-hover);
+    --c-button-hover-background-color: transparent;
+    --c-button-hover-border-color: transparent;
+
     display: inline-block;
     min-width: initial;
     min-height: initial;
     padding: 0;
     user-select: none;
     border: 0;
-
-    @media (hover: hover) {
-        &:hover {
-            color: var(--color-link);
-            background-color: transparent;
-            border-color: transparent;
-        }
-    }
-
-    @media (hover: none) {
-        &:active {
-            color: var(--color-link);
-            background-color: transparent;
-            border-color: transparent;
-        }
-    }
 }
 
 /* ▲ shape ▲ */

--- a/src/components/feedback/Alert.vue
+++ b/src/components/feedback/Alert.vue
@@ -93,9 +93,7 @@ const onClosed = async () => {
                 <div v-if="title" class="title">{{ title }}</div>
                 <div>{{ text }}</div>
             </div>
-            <Button v-if="closeable" shape="skeleton" class="closeable-box" @click="onClose">
-                <IconX />
-            </Button>
+            <Button v-if="closeable" shape="skeleton" class="closeable-box" :prefix-icon="IconX" aria-label="閉じる" @click="onClose" />
         </div>
     </OpacityTransition>
 </template>

--- a/src/components/feedback/Drawer.vue
+++ b/src/components/feedback/Drawer.vue
@@ -147,10 +147,10 @@ defineExpose({ transitionFrom });
                         size="large"
                         shape="skeleton"
                         class="closeable-box"
+                        :prefix-icon="IconX"
+                        aria-label="閉じる"
                         @click="onClose"
-                    >
-                        <IconX class="closeable-icon" />
-                    </Button>
+                    />
                     <div
                         v-if="hasSlot('header')"
                         class="header"
@@ -211,7 +211,7 @@ defineExpose({ transitionFrom });
         right: 0;
         z-index: 1;
         padding: 8px;
-        .closeable-icon {
+        :deep(.button-icon) {
             width: var(--font-size-large);
             height: var(--font-size-large);
         }

--- a/src/components/feedback/Modal.vue
+++ b/src/components/feedback/Modal.vue
@@ -161,9 +161,7 @@ const onOutsideClick = computed(() => ({
                         class="modal"
                         :class="[size, shape, { 'is-center': center, 'is-full-size-by-sp': isFullSizeBySp }]"
                     >
-                        <Button size="large" shape="skeleton" class="closeable-box" @click="onClose">
-                            <IconX class="closeable-icon" />
-                        </Button>
+                        <Button size="large" shape="skeleton" class="closeable-box" :prefix-icon="IconX" aria-label="閉じる" @click="onClose" />
                         <div class="inner">
                             <div class="box">
                                 <div v-if="title" class="title">{{ title }}</div>
@@ -230,7 +228,7 @@ const onOutsideClick = computed(() => ({
         right: 0;
         z-index: 1;
         padding: 8px;
-        .closeable-icon {
+        :deep(.button-icon) {
             width: var(--font-size-large);
             height: var(--font-size-large);
         }

--- a/src/components/feedback/NotificationItem.vue
+++ b/src/components/feedback/NotificationItem.vue
@@ -160,10 +160,10 @@ defineExpose({ flg, transitioning, isShowing, onClosed, transitionFrom });
                             v-if="notification.closeable"
                             shape="skeleton"
                             class="closeable-box"
+                            :prefix-icon="IconX"
+                            aria-label="閉じる"
                             @click="onClose"
-                        >
-                            <IconX />
-                        </Button>
+                        />
                     </div>
                 </component>
             </TranslateTransition>

--- a/src/components/feedback/Rating.vue
+++ b/src/components/feedback/Rating.vue
@@ -106,15 +106,15 @@ watch(model, (v) => {
                 :size="size"
                 shape="link"
                 :readonly="readonly"
+                :prefix-icon="IconStar"
+                :aria-label="`${r.value}点`"
                 :style="`opacity: ${variant === 'dynamic' ? dynamicColors[i] : '100%'}`"
                 @mouseover="onHover(r.value)"
                 @mouseleave="onLeave"
                 @click="onClick(r.value)"
                 v-for="r in rate"
                 :key="r.value"
-            >
-                <IconStar class="icon" />
-            </Button>
+            />
         </div>
     </div>
 </template>
@@ -135,7 +135,7 @@ watch(model, (v) => {
         position: relative;
         display: flex;
         .button {
-            .icon {
+            :deep(.button-icon) {
                 width: var(--c-rating-height);
                 height: var(--c-rating-height);
                 color: var(--c-rating-color);
@@ -146,7 +146,7 @@ watch(model, (v) => {
             }
             &.is-over {
                 background-color: transparent;
-                .icon {
+                :deep(.button-icon) {
                     fill: var(--c-rating-background-color);
                 }
             }
@@ -156,7 +156,7 @@ watch(model, (v) => {
                 width: calc(var(--c-rating-height) / 2);
                 height: var(--c-rating-height);
                 overflow: hidden;
-                .icon {
+                :deep(.button-icon) {
                     position: absolute;
                     top: 0;
                     left: 0;
@@ -168,14 +168,14 @@ watch(model, (v) => {
 }
 
 .dynamic {
-    :deep(.icon) {
+    :deep(.button-icon) {
         --c-rating-color: var(--mi-orange) !important;
         --c-rating-background-color: var(--mi-orange) !important;
     }
 }
 
 .flat {
-    :deep(.icon) {
+    :deep(.button-icon) {
         --c-rating-color: var(--mi-orange) !important;
         --c-rating-background-color: var(--mi-orange) !important;
     }

--- a/src/components/inner-parts/FieldFrame.vue
+++ b/src/components/inner-parts/FieldFrame.vue
@@ -100,7 +100,8 @@ defineExpose({ frameRef });
                 'is-focus': isFocus,
                 'is-required': required,
                 'is-inputed': forceInputed || (value != null && value !== ''),
-                'is-disabled': disabled
+                'is-disabled': disabled,
+                'is-error': errors.length > 0
             }
         ]"
     >
@@ -413,6 +414,12 @@ defineExpose({ frameRef });
 }
 
 /* ▲ variant ▲ */
+
+/* variant より詳細度を上げてオーバーライドする */
+
+.component-input-frame.is-error {
+    --c-field-frame-border-color: var(--color-danger);
+}
 
 /* ▼ size ▼ */
 

--- a/src/components/navigation/BottomNav.vue
+++ b/src/components/navigation/BottomNav.vue
@@ -73,21 +73,16 @@ const onClick = (item: MiBottomNavItem) => {
     >
         <div class="component-bottom-nav-inner" :class="{ 'is-center': center }">
             <Button
-                v-for="(item, i) in items"
+                v-for="item in items"
                 :key="item.to"
                 class="item"
                 :class="{ 'is-current': item.isCurrent }"
                 :size="size"
                 shape="skeleton"
-            >
-                <component :is="item.icon" class="icon" />
-                <span
-                    class="label"
-                    :class="{ 'is-disabled': items.length === i + 1 }"
-                    @click="onClick(item)"
-                    >{{ item.label }}</span
-                >
-            </Button>
+                :prefix-icon="item.icon"
+                :label="item.label"
+                @click="onClick(item)"
+            />
         </div>
     </component>
 </template>
@@ -122,14 +117,14 @@ const onClick = (item: MiBottomNavItem) => {
         justify-content: flex-start;
         width: 100%;
         height: var(--c-bottom-nav-height);
-        .icon {
+        :deep(.button-icon) {
             width: calc(var(--c-bottom-nav-font-size) * 2);
             height: 100%;
             transition:
                 width 0.2s,
                 height 0.2s;
         }
-        .label {
+        :deep(.button-label) {
             position: absolute;
             bottom: -1.5em;
             font-size: var(--font-size-small);
@@ -139,11 +134,11 @@ const onClick = (item: MiBottomNavItem) => {
         &.is-current {
             color: var(--color-text-primary);
             pointer-events: none;
-            .icon {
+            :deep(.button-icon) {
                 width: calc(var(--c-bottom-nav-font-size) * 1.5);
                 height: calc(var(--c-bottom-nav-font-size) * 2.2);
             }
-            .label {
+            :deep(.button-label) {
                 bottom: calc(var(--c-bottom-nav-font-size) * 0.25);
             }
         }
@@ -151,11 +146,11 @@ const onClick = (item: MiBottomNavItem) => {
         /* hover */
         @media (hover: hover) {
             &:hover {
-                .icon {
+                :deep(.button-icon) {
                     width: calc(var(--c-bottom-nav-font-size) * 1.5);
                     height: calc(var(--c-bottom-nav-font-size) * 2.2);
                 }
-                .label {
+                :deep(.button-label) {
                     bottom: calc(var(--c-bottom-nav-font-size) * 0.25);
                 }
             }
@@ -163,11 +158,11 @@ const onClick = (item: MiBottomNavItem) => {
 
         @media (hover: none) {
             &:active {
-                .icon {
+                :deep(.button-icon) {
                     width: calc(var(--c-bottom-nav-font-size) * 1.5);
                     height: calc(var(--c-bottom-nav-font-size) * 2.2);
                 }
-                .label {
+                :deep(.button-label) {
                     bottom: calc(var(--c-bottom-nav-font-size) * 0.25);
                 }
             }

--- a/src/components/navigation/Pagination.vue
+++ b/src/components/navigation/Pagination.vue
@@ -162,9 +162,7 @@ const onClick = (page: number | undefined) => {
                 class="pagination-item prev-first"
                 :class="{ 'is-disabled': currentPage === 1 }"
             >
-                <Button shape="skeleton" class="pagination-item-button" @click="onClick(1)">
-                    ≪
-                </Button>
+                <Button shape="skeleton" class="pagination-item-button" label="≪" aria-label="最初のページへ" @click="onClick(1)" />
             </li>
             <li
                 v-if="!hidePrevNextButton"
@@ -174,10 +172,10 @@ const onClick = (page: number | undefined) => {
                 <Button
                     shape="skeleton"
                     class="pagination-item-button"
+                    label="〈"
+                    aria-label="前のページへ"
                     @click="onClick(paginationPrev)"
-                >
-                    〈
-                </Button>
+                />
             </li>
             <li
                 v-for="(page, i) in pages"
@@ -191,10 +189,10 @@ const onClick = (page: number | undefined) => {
                     shape="skeleton"
                     v-if="page.num !== 0"
                     class="pagination-item-button"
+                    :label="String(page.num)"
+                    :aria-label="`${page.num}ページへ`"
                     @click="onClick(page.num)"
-                >
-                    {{ page.num }}
-                </Button>
+                />
             </li>
             <li
                 v-if="!hidePrevNextButton"
@@ -204,19 +202,17 @@ const onClick = (page: number | undefined) => {
                 <Button
                     shape="skeleton"
                     class="pagination-item-button"
+                    label="〉"
+                    aria-label="次のページへ"
                     @click="onClick(paginationNext)"
-                >
-                    〉
-                </Button>
+                />
             </li>
             <li
                 v-if="!hideFirstLastButton"
                 class="pagination-item next-last"
                 :class="{ 'is-disabled': currentPage === total }"
             >
-                <Button shape="skeleton" class="pagination-item-button" @click="onClick(total)">
-                    ≫
-                </Button>
+                <Button shape="skeleton" class="pagination-item-button" label="≫" aria-label="最後のページへ" @click="onClick(total)" />
             </li>
         </ul>
     </component>

--- a/src/components/navigation/Step.vue
+++ b/src/components/navigation/Step.vue
@@ -51,6 +51,7 @@ const TransitionComponent = markRaw(
 const transitionFrom = ref('right');
 
 const onChangeTab = (id: string) => {
+    if (id === currentStep.value) return;
     const currentIndex = props.steps.findIndex((step) => step.id === currentStep.value);
     const newIndex = props.steps.findIndex((step) => step.id === id);
     const isPrev = currentIndex > newIndex;
@@ -90,15 +91,14 @@ const hasSlot = (name: string) => {
     <div class="component-step" :class="[size, position]">
         <div class="step-header" :class="{ 'no-separator': noSeparator }">
             <template v-for="(step, i) in steps" :key="step.id">
-                <Button
-                    :size="size"
-                    shape="skeleton"
-                    :readonly="currentStep === step.id"
+                <button
+                    type="button"
                     :disabled="currentStepIndex < i"
                     class="step-button"
                     :class="{
                         'is-success': currentStepIndex > i,
-                        'is-current': currentStepIndex === i
+                        'is-current': currentStepIndex === i,
+                        'is-readonly': currentStep === step.id
                     }"
                     @click="onChangeTab(step.id)"
                 >
@@ -108,7 +108,7 @@ const hasSlot = (name: string) => {
                         </component>
                     </div>
                     <div class="text">{{ step.label }}</div>
-                </Button>
+                </button>
                 <div
                     class="step-separator"
                     :class="{
@@ -131,16 +131,14 @@ const hasSlot = (name: string) => {
                 class="step-footer"
                 :class="{ 'no-separator': noSeparator }"
             >
-                <Button :size="size" :disabled="currentStepIndex === 0" @click="onPrev"
-                    >Prev</Button
-                >
+                <Button :size="size" :disabled="currentStepIndex === 0" label="Prev" @click="onPrev" />
                 <Button
                     variant="success"
                     :size="size"
                     :disabled="currentStepIndex + 1 === steps.length"
+                    label="Next"
                     @click="onNext"
-                    >Next</Button
-                >
+                />
             </div>
         </div>
     </div>
@@ -165,11 +163,22 @@ const hasSlot = (name: string) => {
             display: flex;
             flex-direction: column;
             gap: 0;
+            align-items: center;
             width: var(--c-step-button-height);
             padding: 0;
+            font-size: var(--c-step-font-size, var(--font-size-medium));
+            color: inherit;
+            cursor: pointer;
+            background: transparent;
+            border: 0;
             transition:
                 opacity 0.2s,
                 color 0.2s;
+            &:disabled,
+            &.is-readonly {
+                cursor: not-allowed;
+                opacity: 0.5;
+            }
             .icon {
                 display: flex;
                 align-items: center;

--- a/src/components/navigation/Tab.vue
+++ b/src/components/navigation/Tab.vue
@@ -113,11 +113,12 @@ defineExpose({ tabAlignProperty, tabButtonRef, currentTabClientRects });
                 shape="skeleton"
                 :class="{ 'is-current': currentTab === tab.id }"
                 :readonly="currentTab === tab.id"
+                :prefix-icon="tab.icon"
+                :label="tab.label"
                 v-for="tab in tabs"
                 :key="tab.id"
                 @click="onChangeTab(tab.id)"
-                ><component :is="tab.icon" v-if="tab.icon" />{{ tab.label }}</Button
-            >
+            />
             <span class="active-border" />
         </div>
         <component :is="TransitionComponent" :from="transitionFrom">

--- a/src/stories/basic/Button.stories.ts
+++ b/src/stories/basic/Button.stories.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue';
 import Button from '@/components/basic/Button.vue';
+import { Star as IconStar, Download as IconDownload } from 'lucide-vue-next';
 import type { Args, Meta, StoryObj } from '@storybook/vue3-vite';
 
 const meta: Meta<typeof Button> = {
@@ -9,10 +10,10 @@ const meta: Meta<typeof Button> = {
         setup() {
             return { args };
         },
-        template: '<Button v-bind="args">{{args.default}}</Button>'
+        template: '<Button v-bind="args" />'
     }),
     args: {
-        default: 'ボタン'
+        label: 'ボタン'
     },
     argTypes: {
         // TODO: script setupに未対応のため二重定義
@@ -23,7 +24,7 @@ const meta: Meta<typeof Button> = {
             options: ['small', 'medium', 'large']
         },
         shape: {
-            options: ['normal', 'rounded', 'circle', 'square', 'skeleton']
+            options: ['normal', 'rounded', 'circle', 'square', 'skeleton', 'link']
         },
         onClick: { action: 'click' }
     }
@@ -40,27 +41,15 @@ export const PropsVariant: Story = {
         setup: () => ({
             args,
             params: ref([
-                {
-                    variant: 'primary'
-                },
-                {
-                    variant: 'secondary'
-                },
-                {
-                    variant: 'info'
-                },
-                {
-                    variant: 'success'
-                },
-                {
-                    variant: 'warning'
-                },
-                {
-                    variant: 'danger'
-                }
+                { variant: 'primary' },
+                { variant: 'secondary' },
+                { variant: 'info' },
+                { variant: 'success' },
+                { variant: 'warning' },
+                { variant: 'danger' }
             ])
         }),
-        template: `<Button v-for="param in params" :key="param.shape" v-bind="{...args, ...param}">{{param.variant}}</Button>`
+        template: `<Button v-for="param in params" :key="param.variant" v-bind="{...args, ...param}" :label="param.variant" />`
     })
 };
 
@@ -70,18 +59,12 @@ export const PropsSize: Story = {
         setup: () => ({
             args,
             params: ref([
-                {
-                    size: 'large'
-                },
-                {
-                    size: 'medium'
-                },
-                {
-                    size: 'small'
-                }
+                { size: 'large' },
+                { size: 'medium' },
+                { size: 'small' }
             ])
         }),
-        template: `<Button v-for="param in params" :key="param.shape" v-bind="{...args, ...param}">{{param.size}}</Button>`
+        template: `<Button v-for="param in params" :key="param.size" v-bind="{...args, ...param}" :label="param.size" />`
     })
 };
 
@@ -91,30 +74,16 @@ export const PropsShape: Story = {
         setup: () => ({
             args,
             params: ref([
-                {
-                    shape: 'normal'
-                },
-                {
-                    shape: 'rounded'
-                },
-                {
-                    shape: 'no-radius'
-                },
-                {
-                    shape: 'circle'
-                },
-                {
-                    shape: 'square'
-                },
-                {
-                    shape: 'skeleton'
-                },
-                {
-                    shape: 'link'
-                }
+                { shape: 'normal' },
+                { shape: 'rounded' },
+                { shape: 'no-radius' },
+                { shape: 'circle' },
+                { shape: 'square' },
+                { shape: 'skeleton' },
+                { shape: 'link' }
             ])
         }),
-        template: `<Button v-for="param in params" :key="param.shape" v-bind="{...args, ...param}">{{param.shape}}</Button>`
+        template: `<Button v-for="param in params" :key="param.shape" v-bind="{...args, ...param}" :label="param.shape" />`
     })
 };
 
@@ -131,6 +100,46 @@ export const PropsDisabled: Story = {
 
 export const LongText: Story = {
     args: {
-        default: '長いテキストのケース'
+        label: '長いテキストのケース'
     }
+};
+
+export const PrefixIcon: Story = {
+    render: (args: Args) => ({
+        components: { Button },
+        setup: () => ({ args, IconDownload }),
+        template: '<Button v-bind="args" :prefix-icon="IconDownload" label="ダウンロード" />'
+    })
+};
+
+export const SuffixIcon: Story = {
+    render: (args: Args) => ({
+        components: { Button },
+        setup: () => ({ args, IconStar }),
+        template: '<Button v-bind="args" :suffix-icon="IconStar" label="お気に入り" />'
+    })
+};
+
+export const StatusAutoIcon: Story = {
+    render: (args: Args) => ({
+        components: { Button },
+        setup: () => ({
+            args,
+            params: ref([
+                { variant: 'info', label: 'Info' },
+                { variant: 'success', label: 'Success' },
+                { variant: 'warning', label: 'Warning' },
+                { variant: 'danger', label: 'Danger' }
+            ])
+        }),
+        template: `<Button v-for="param in params" :key="param.variant" v-bind="{...args, ...param}" />`
+    })
+};
+
+export const PrefixIconOverride: Story = {
+    render: (args: Args) => ({
+        components: { Button },
+        setup: () => ({ args, IconStar }),
+        template: '<Button v-bind="args" variant="danger" :prefix-icon="IconStar" label="カスタムアイコン" />'
+    })
 };

--- a/src/stories/feedback/Dialog.stories.ts
+++ b/src/stories/feedback/Dialog.stories.ts
@@ -14,11 +14,11 @@ const meta: Meta<typeof Dialog> = {
             return { args };
         },
         template: `
-<Button @click="args.modelValue = true">Open Dialog</Button>
+<Button label="Open Dialog" @click="args.modelValue = true" />
 <Dialog v-bind="args">
     'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
     <template #footer>
-        <Button @click="args.modelValue = false">Cancel</Button>
+        <Button label="Cancel" @click="args.modelValue = false" />
     </template>
 </Dialog>`
     }),
@@ -70,11 +70,11 @@ export const PropsVariant: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.variant">
-    <Button :variant="param.variant" @click="param.modelValue = true">Open Dialog({{param.variant}})</Button>
+    <Button :variant="param.variant" :label="'Open Dialog(' + param.variant + ')'" @click="param.modelValue = true" />
     <Dialog v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         <template #footer>
-            <Button @click="param.modelValue = false">Cancel</Button>
+            <Button label="Cancel" @click="param.modelValue = false" />
         </template>
     </Dialog>
 </template>`
@@ -111,11 +111,11 @@ export const PropsSize: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.size">
-    <Button @click="param.modelValue = true">Open Dialog({{param.size}})</Button>
+    <Button :label="'Open Dialog(' + param.size + ')'" @click="param.modelValue = true" />
     <Dialog v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         <template #footer>
-            <Button @click="param.modelValue = false">Cancel</Button>
+            <Button label="Cancel" @click="param.modelValue = false" />
         </template>
     </Dialog>
 </template>`
@@ -140,11 +140,11 @@ export const PropsShape: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.shape">
-    <Button @click="param.modelValue = true">Open Dialog({{param.shape}})</Button>
+    <Button :label="'Open Dialog(' + param.shape + ')'" @click="param.modelValue = true" />
     <Dialog v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         <template #footer>
-            <Button @click="param.modelValue = false">Cancel</Button>
+            <Button label="Cancel" @click="param.modelValue = false" />
         </template>
     </Dialog>
 </template>`
@@ -181,11 +181,11 @@ export const PropsPosition: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.position">
-    <Button @click="param.modelValue = true">Open Dialog({{param.position}})</Button>
+    <Button :label="'Open Dialog(' + param.position + ')'" @click="param.modelValue = true" />
     <Dialog v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         <template #footer>
-            <Button @click="param.modelValue = false">Cancel</Button>
+            <Button label="Cancel" @click="param.modelValue = false" />
         </template>
     </Dialog>
 </template>`
@@ -222,11 +222,11 @@ export const PropsTransitionFrom: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.transitionFrom">
-    <Button @click="param.modelValue = true">Open Dialog({{param.transitionFrom}})</Button>
+    <Button :label="'Open Dialog(' + param.transitionFrom + ')'" @click="param.modelValue = true" />
     <Dialog v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         <template #footer>
-            <Button @click="param.modelValue = false">Cancel</Button>
+            <Button label="Cancel" @click="param.modelValue = false" />
         </template>
     </Dialog>
 </template>`
@@ -275,7 +275,7 @@ export const PropsFrameComponent: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.frameComponent">
-    <Button @click="param.modelValue.value = true">Open Dialog{{param.frameComponent ? ' by frame' : ''}}</Button>
+    <Button :label="'Open Dialog' + (param.frameComponent ? ' by frame' : '')" @click="param.modelValue.value = true" />
     <Dialog v-bind="{...args, ...param}" v-model="param.modelValue.value">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </Dialog>
@@ -289,7 +289,7 @@ export const StoryPlayer: Story = {
         components: { Dialog, Button, Progress, IconPlay, IconPause, IconX },
         setup: () => ({ args, progressModel: 75 }),
         template: `
-<Button @click="args.modelValue = true">Open Player</Button>
+<Button label="Open Player" @click="args.modelValue = true" />
 <Dialog v-bind="args">
     <Progress v-model="progressModel" variant="primary" shape="slim-line" no-text style="width: calc(100% + 18px);margin: 0 -9px;position: absolute; top:-8px;" />
     <div style="display: flex;gap: 8px;width:100%;">
@@ -297,9 +297,9 @@ export const StoryPlayer: Story = {
             <div>Title</div><div>sample artist</div>
         </div>
         <div style="display: flex; align-items: center;justify-content: space-evenly;flex-grow: 1;">
-            <Button shape="skeleton"><IconPlay style="width: 24px; height:24px;" /></Button>
-            <Button shape="skeleton"><IconPause style="width: 24px; height:24px;" /></Button>
-            <Button shape="skeleton" @click="args.modelValue = false"><IconX style="width: 24px; height:24px;" /></Button>
+            <Button shape="skeleton" :prefix-icon="IconPlay" aria-label="再生" />
+            <Button shape="skeleton" :prefix-icon="IconPause" aria-label="一時停止" />
+            <Button shape="skeleton" :prefix-icon="IconX" aria-label="閉じる" @click="args.modelValue = false" />
         </div>
     </div>
 </Dialog>`

--- a/src/stories/feedback/Drawer.stories.ts
+++ b/src/stories/feedback/Drawer.stories.ts
@@ -11,7 +11,7 @@ const meta: Meta<typeof Drawer> = {
             return { args };
         },
         template: `
-<Button @click="args.modelValue = true">Open Drawer</Button>
+<Button label="Open Drawer" @click="args.modelValue = true" />
 <Drawer v-bind="args">
     'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
 </Drawer>`
@@ -53,7 +53,7 @@ export const PropsSize: Story = {
         }),
         template: `
 <div v-for="param in params" :key="param.size">
-    <Button @click="param.modelValue = true">Open Drawer({{param.size}})</Button>
+    <Button :label="'Open Drawer(' + param.size + ')'" @click="param.modelValue = true" />
     <Drawer v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </Drawer>
@@ -87,7 +87,7 @@ export const PropsPosition: Story = {
         }),
         template: `
 <div v-for="param in params" :key="param.position">
-    <Button @click="param.modelValue = true">Open Drawer({{param.position}})</Button>
+    <Button :label="'Open Drawer(' + param.position + ')'" @click="param.modelValue = true" />
     <Drawer v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </Drawer>
@@ -102,7 +102,7 @@ export const PropsCenter: Story = {
             return { args };
         },
         template: `
-<Button @click="args.modelValue = true">Open Drawer</Button>
+<Button label="Open Drawer" @click="args.modelValue = true" />
 <Drawer v-bind="args">
     <template #header>center is header</template>
     <template #footer>center is footer</template>

--- a/src/stories/feedback/Modal.stories.ts
+++ b/src/stories/feedback/Modal.stories.ts
@@ -12,7 +12,7 @@ const meta: Meta<typeof Modal> = {
             return { args };
         },
         template: `
-<Button @click="args.modelValue = true">Open Modal</Button>
+<Button label="Open Modal" @click="args.modelValue = true" />
 <Modal v-bind="args">
     'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
 </Modal>`
@@ -57,7 +57,7 @@ export const PropsSize: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.size">
-    <Button @click="param.modelValue = true">Open Modal({{param.size}})</Button>
+    <Button :label="'Open Modal(' + param.size + ')'" @click="param.modelValue = true" />
     <Modal v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </Modal>
@@ -95,7 +95,7 @@ export const PropsIsFullSizeBySP: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.size">
-    <Button @click="param.modelValue = true">Open Modal({{param.size}})</Button>
+    <Button :label="'Open Modal(' + param.size + ')'" @click="param.modelValue = true" />
     <Modal v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </Modal>
@@ -121,7 +121,7 @@ export const PropsShape: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.shape">
-    <Button @click="param.modelValue = true">Open Modal({{param.shape}})</Button>
+    <Button :label="'Open Modal(' + param.shape + ')'" @click="param.modelValue = true" />
     <Modal v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </Modal>
@@ -159,7 +159,7 @@ export const PropsTransitionFrom: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.transitionFrom">
-    <Button @click="param.modelValue = true">Open Modal({{param.transitionFrom}})</Button>
+    <Button :label="'Open Modal(' + param.transitionFrom + ')'" @click="param.modelValue = true" />
     <Modal v-bind="{...args, ...param}" v-model="param.modelValue">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </Modal>
@@ -203,7 +203,7 @@ export const PropsFrameComponent: Story = {
         }),
         template: `
 <template v-for="param in params" :key="param.frameComponent">
-    <Button @click="param.modelValue.value = true">Open Modal{{param.frameComponent ? ' by frame' : ''}}</Button>
+    <Button :label="'Open Modal' + (param.frameComponent ? ' by frame' : '')" @click="param.modelValue.value = true" />
     <Modal v-bind="{...args, ...param}" v-model="param.modelValue.value">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </Modal>

--- a/src/stories/feedback/Notifications.stories.ts
+++ b/src/stories/feedback/Notifications.stories.ts
@@ -18,7 +18,7 @@ const meta: Meta<MiNotificationOption> = {
             };
         },
         template: `
-<Button @click="onSetNotification">Open Notifications</Button>
+<Button label="Open Notifications" @click="onSetNotification" />
 <Notifications />`
     }),
     args: {
@@ -111,7 +111,7 @@ export const ParamsVariant: Story = {
         },
         template: `
 <div v-for="param in params" :key="param.variant">
-    <Button :variant="param.variant" @click="onSetNotification(param)">Open Notifications({{param.variant}})</Button>
+    <Button :variant="param.variant" :label="'Open Notifications(' + param.variant + ')'" @click="onSetNotification(param)" />
 </div>
 <Notifications />`
     })
@@ -146,7 +146,7 @@ export const ParamsSize: Story = {
         },
         template: `
 <div v-for="param in params" :key="param.size">
-    <Button @click="onSetNotification(param)">Open Notifications({{param.size}})</Button>
+    <Button :label="'Open Notifications(' + param.size + ')'" @click="onSetNotification(param)" />
 </div>
 <Notifications />`
     })
@@ -181,7 +181,7 @@ export const ParamsShape: Story = {
         },
         template: `
 <div v-for="param in params" :key="param.shape">
-    <Button @click="onSetNotification(param)">Open Notifications({{param.shape}})</Button>
+    <Button :label="'Open Notifications(' + param.shape + ')'" @click="onSetNotification(param)" />
 </div>
 <Notifications />`
     })
@@ -219,7 +219,7 @@ export const ParamsPosition: Story = {
         },
         template: `
 <div v-for="param in params" :key="param.position">
-    <Button @click="onSetNotification(param)">Open Notifications({{param.position}})</Button>
+    <Button :label="'Open Notifications(' + param.position + ')'" @click="onSetNotification(param)" />
 </div>
 <Notifications />`
     })

--- a/src/test/components/basic/Button.spec.ts
+++ b/src/test/components/basic/Button.spec.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { defineComponent, h, markRaw } from 'vue';
 import Button from '@/components/basic/Button.vue';
+
+const StubIcon = markRaw(defineComponent({
+    name: 'StubIcon',
+    render: () => h('svg', { class: 'stub-icon' })
+}));
 
 describe('Button', () => {
     it('デフォルト props が適用される', () => {
@@ -39,8 +45,54 @@ describe('Button', () => {
         expect(wrapper.find('button').classes()).toContain('is-readonly');
     });
 
-    it('slot コンテンツが表示される', () => {
-        const wrapper = mount(Button, { slots: { default: 'ボタン' } });
-        expect(wrapper.text()).toBe('ボタン');
+    it('label prop でテキストが表示される', () => {
+        const wrapper = mount(Button, { props: { label: 'ボタン' } });
+        expect(wrapper.find('.button-label').text()).toBe('ボタン');
+    });
+
+    it('label が未指定のとき .button-label が描画されない', () => {
+        const wrapper = mount(Button);
+        expect(wrapper.find('.button-label').exists()).toBe(false);
+    });
+
+    it('prefixIcon を指定するとアイコンが描画される', () => {
+        const wrapper = mount(Button, { props: { prefixIcon: StubIcon } });
+        expect(wrapper.findComponent(StubIcon).exists()).toBe(true);
+    });
+
+    it('suffixIcon を指定するとアイコンが描画される', () => {
+        const wrapper = mount(Button, { props: { suffixIcon: StubIcon } });
+        expect(wrapper.findComponent(StubIcon).exists()).toBe(true);
+    });
+
+    it.each(['info', 'success', 'warning', 'danger'] as const)(
+        'variant=%s のとき auto-icon が付与される',
+        (variant) => {
+            const wrapper = mount(Button, { props: { variant } });
+            expect(wrapper.findAll('.button-icon').length).toBe(1);
+        }
+    );
+
+    it.each(['primary', 'secondary'] as const)(
+        'variant=%s のとき auto-icon が付与されない',
+        (variant) => {
+            const wrapper = mount(Button, { props: { variant } });
+            expect(wrapper.findAll('.button-icon').length).toBe(0);
+        }
+    );
+
+    it('prefixIcon 明示指定で auto-icon がオーバーライドされる', () => {
+        const wrapper = mount(Button, { props: { variant: 'info', prefixIcon: StubIcon } });
+        const icons = wrapper.findAll('.button-icon');
+        expect(icons.length).toBe(1);
+        expect(wrapper.findComponent(StubIcon).exists()).toBe(true);
+    });
+
+    it('icon-only ボタンで aria-label が button に伝搬する', () => {
+        const wrapper = mount(Button, {
+            props: { prefixIcon: StubIcon },
+            attrs: { 'aria-label': '閉じる' }
+        });
+        expect(wrapper.find('button').attributes('aria-label')).toBe('閉じる');
     });
 });

--- a/src/test/components/inner-parts/FieldFrame.spec.ts
+++ b/src/test/components/inner-parts/FieldFrame.spec.ts
@@ -45,4 +45,14 @@ describe('FieldFrame', () => {
         const wrapper = mount(FieldFrame, { props: { value: 'テスト入力' } });
         expect(wrapper.find('.component-input-frame').classes()).toContain('is-inputed');
     });
+
+    it('errors があるとき is-error クラスが付く', () => {
+        const wrapper = mount(FieldFrame, { props: { errors: ['入力が必要です'] } });
+        expect(wrapper.find('.component-input-frame').classes()).toContain('is-error');
+    });
+
+    it('errors が空のとき is-error クラスが付かない', () => {
+        const wrapper = mount(FieldFrame, { props: { errors: [] } });
+        expect(wrapper.find('.component-input-frame').classes()).not.toContain('is-error');
+    });
 });

--- a/src/test/components/navigation/BottomNav.spec.ts
+++ b/src/test/components/navigation/BottomNav.spec.ts
@@ -18,7 +18,7 @@ describe('BottomNav', () => {
 
     it('items のラベルが表示される', () => {
         const wrapper = mount(BottomNav, { props: { items } });
-        const labels = wrapper.findAll('.label');
+        const labels = wrapper.findAll('.button-label');
         expect(labels[0].text()).toBe('ホーム');
         expect(labels[1].text()).toBe('設定');
     });
@@ -55,7 +55,7 @@ describe('BottomNav', () => {
         try {
             const emptyToItems = [{ label: 'ホーム', icon: IconHome, to: '' }];
             const wrapper = mount(BottomNav, { props: { items: emptyToItems as any } });
-            await wrapper.find('.label').trigger('click');
+            await wrapper.find('.item').trigger('click');
             expect(hrefSetter).not.toHaveBeenCalled();
         } finally {
             Object.defineProperty(window, 'location', {
@@ -74,7 +74,7 @@ describe('BottomNav', () => {
         });
         try {
             const wrapper = mount(BottomNav, { props: { items } });
-            await wrapper.findAll('.label')[1].trigger('click');
+            await wrapper.findAll('.item')[1].trigger('click');
             expect(hrefSetter).toHaveBeenCalledWith('/settings');
         } finally {
             Object.defineProperty(window, 'location', {
@@ -94,7 +94,7 @@ describe('BottomNav', () => {
         try {
             const maliciousItems = [{ label: 'XSS', icon: IconHome, to: 'javascript:alert(1)' }];
             const wrapper = mount(BottomNav, { props: { items: maliciousItems as any } });
-            await wrapper.find('.label').trigger('click');
+            await wrapper.find('.item').trigger('click');
             expect(hrefSetter).not.toHaveBeenCalled();
         } finally {
             Object.defineProperty(window, 'location', {
@@ -118,7 +118,7 @@ describe('BottomNav', () => {
             global: { plugins: [router] }
         });
         await router.isReady();
-        await wrapper.findAll('.label')[0].trigger('click');
+        await wrapper.findAll('.item')[0].trigger('click');
         expect(pushSpy).toHaveBeenCalledWith('/');
         pushSpy.mockRestore();
     });

--- a/src/test/components/navigation/Step.spec.ts
+++ b/src/test/components/navigation/Step.spec.ts
@@ -150,6 +150,20 @@ describe('Step', () => {
         expect(wrapper.emitted('prev')).toBeTruthy();
     });
 
+    it('現在のステップのヘッダーをクリックしても next/prev イベントが発火しない', async () => {
+        const wrapper = mount(Step, {
+            props: {
+                steps,
+                modelValue: 'step2',
+                'onUpdate:modelValue': (v: string | undefined) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const buttons = wrapper.findAll('.step-button');
+        await buttons[1].trigger('click');
+        expect(wrapper.emitted('next')).toBeUndefined();
+        expect(wrapper.emitted('prev')).toBeUndefined();
+    });
+
     it('Next ボタンをクリックすると v-model が次の step に更新される', async () => {
         const wrapper = mount(Step, {
             props: {


### PR DESCRIPTION
## 概要

Button コンポーネントのAPIを全面リデザインする破壊的変更です。

### 変更点

- **slot廃止 → `label` prop**: テキストコンテンツをpropで管理
- **`prefixIcon` / `suffixIcon` props追加**: アイコンをComponent型のpropで指定
- **status variant auto-icon**: info/success/warning/danger に自動でアイコンを付与（`prefixIcon` 指定で上書き可）
- **danger塗りつぶし統一**: アウトラインスタイルから他status variantと同じ塗りつぶしに変更

### status auto-icon マッピング

| variant | アイコン |
|---------|---------|
| info | `Info` |
| success | `CheckCircle2` |
| warning | `AlertTriangle` |
| danger | `XOctagon` |

### 影響範囲

- `Button.vue`: 新API実装
- 内部コンポーネント全箇所の移行（Alert, Modal, Drawer, NotificationItem, Rating, Pagination, Tab, BottomNav, Step）
- `FieldFrame.vue`: `is-error` クラスの独立化
- `Step.vue`: 現在ステップのクリック防止ガード追加
- Storybook / Playground / テスト / DESIGN.md を全面更新

## テスト計画

- [x] `pnpm lint:fix` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm test:run` — 731テスト全パス
- [x] Playground 3環境（Vue / Nuxt3 / Nuxt4）での目視確認
- [ ] Storybook での目視確認

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>