### PR TITLE
fix: Checkbox/Radio/Switchのキーボードフォーカス不可問題を修正

### DIFF
--- a/src/components/controls/Checkbox.vue
+++ b/src/components/controls/Checkbox.vue
@@ -138,7 +138,19 @@ if (fieldVal.value == null && model.value != null) {
     font-size: var(--c-checkbox-font-size);
     text-align: left;
     :where(.checkbox) {
-        display: none;
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        white-space: nowrap;
+        border: 0;
+        clip-path: inset(50%);
+    }
+    :where(.input:has(.checkbox:focus-visible)) {
+        outline: var(--focus-ring-width) solid var(--focus-ring-color);
+        outline-offset: var(--focus-ring-offset);
     }
     &.is-disabled {
         pointer-events: none;

--- a/src/components/controls/Radio.vue
+++ b/src/components/controls/Radio.vue
@@ -137,7 +137,19 @@ if (fieldVal.value == null && model.value != null) {
     font-size: var(--c-radio-font-size);
     text-align: left;
     :where(.radio) {
-        display: none;
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        white-space: nowrap;
+        border: 0;
+        clip-path: inset(50%);
+    }
+    :where(.input:has(.radio:focus-visible)) {
+        outline: var(--focus-ring-width) solid var(--focus-ring-color);
+        outline-offset: var(--focus-ring-offset);
     }
     &.is-disabled {
         pointer-events: none;

--- a/src/components/controls/Switch.vue
+++ b/src/components/controls/Switch.vue
@@ -127,7 +127,19 @@ if (fieldVal.value == null && model.value != null) {
     font-size: var(--c-switch-font-size);
     text-align: left;
     :where(.checkbox) {
-        display: none;
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        white-space: nowrap;
+        border: 0;
+        clip-path: inset(50%);
+    }
+    :where(.checkbox:focus-visible ~ .switch) {
+        outline: var(--focus-ring-width) solid var(--focus-ring-color);
+        outline-offset: var(--focus-ring-offset);
     }
     :where(.switch) {
         position: relative;


### PR DESCRIPTION
## Summary\n\n- Checkbox / Radio / Switch の `display: none` を visually-hidden パターンに変更し、キーボードフォーカスを有効化\n- `:has(:focus-visible)` を使用してフォーカスリングを視覚的な要素に委譲\n  - Checkbox / Radio: `.input`（label）全体にフォーカスリング表示\n  - Switch: `.switch`（トラック部分）にフォーカスリング表示\n- `clip: rect()` は Stylelint の `property-no-deprecated` に抵触するため `clip-path: inset(50%)` を採用\n\nCloses #848\n\n## Test plan\n\n- [x] `pnpm type-check` パス\n- [x] `pnpm lint:fix` パス\n- [x] `pnpm test:run` 全737テストパス\n- [x] Storybook で Checkbox / Radio / Switch に Tab キーでフォーカスが当たることを確認\n- [x] フォーカスリングが視認できることを確認\n- [x] Space キーでトグル操作できることを確認\n\nGenerated with [Claude Code](https://claude.ai/code)