### PR TITLE
feat: Dialog/ModalをshowModal()に移行 (#845)

### DIFF
--- a/src/components/feedback/Dialog.vue
+++ b/src/components/feedback/Dialog.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
-import { ref, computed, useSlots, watch, markRaw, onMounted, type Component } from 'vue';
+import { ref, computed, useSlots, watch, onMounted, onBeforeUnmount, type Component } from 'vue';
 import TeleportRoot from '@/components/inner-parts/TeleportRoot.vue';
-import OpacityTransition from '@/components/inner-parts/OpacityTransition.vue';
-import TranslateTransition from '@/components/inner-parts/TranslateTransition.vue';
-import { sleep } from '@/assets/ts';
 import {
     Info as IconInfo,
     CheckCircle2 as IconCheckCircle2,
     AlertTriangle as IconAlertTriangle,
     XOctagon as IconXOctagon
 } from 'lucide-vue-next';
-import useOutsideClick from '@/directives/useOutsideClick';
 
 const flg = defineModel<boolean>({ default: false });
 const props = withDefaults(
@@ -52,10 +48,6 @@ const props = withDefaults(
          */
         seamless?: boolean;
         /**
-         * 枠外クリック除外要素
-         */
-        outsideClickIgnore?: (Element | string)[];
-        /**
          * フレーム装飾用コンポーネント
          */
         frameComponent?: Component | string;
@@ -67,11 +59,9 @@ const props = withDefaults(
         position: 'center',
         transitionFrom: 'opacity',
         title: '',
-        scroll: false,
         center: false,
         persistent: false,
         seamless: false,
-        outsideClickIgnore: () => ['button', 'dialog'],
         frameComponent: 'div'
     }
 );
@@ -82,38 +72,67 @@ const emit = defineEmits<{
     closed: [];
 }>();
 
-// transition状態
-const TransitionComponent = markRaw(
-    props.transitionFrom === 'opacity' ? OpacityTransition : TranslateTransition
-);
-const transitioning = ref(false);
-const isShowing = computed(() => {
-    if (flg.value) {
-        return true;
-    } else {
-        return transitioning.value;
-    }
-});
-const resolvedTransitionFrom = computed(() => {
-    if (props.transitionFrom === 'top') {
-        return 'top-rebound';
-    } else if (props.transitionFrom === 'right') {
-        return 'right-rebound';
-    } else if (props.transitionFrom === 'bottom') {
-        return 'bottom-rebound';
-    } else if (props.transitionFrom === 'left') {
-        return 'left-rebound';
-    } else {
-        return undefined;
-    }
+const transitionState = ref<'is-opening' | 'is-closing' | ''>('');
+const transitionFromClass = computed(() => {
+    if (props.transitionFrom === 'top') return 'from-top';
+    if (props.transitionFrom === 'right') return 'from-right';
+    if (props.transitionFrom === 'bottom') return 'from-bottom';
+    if (props.transitionFrom === 'left') return 'from-left';
+    return '';
 });
 
 const dialogEl = ref<HTMLDialogElement | null>(null);
+let closeTimeoutId: number | undefined;
+
+const finishClose = () => {
+    if (closeTimeoutId !== undefined) {
+        window.clearTimeout(closeTimeoutId);
+        closeTimeoutId = undefined;
+    }
+    transitionState.value = '';
+    dialogEl.value?.close();
+    document.documentElement.style.overflow = '';
+    emit('closed');
+};
+
+const open = () => {
+    if (closeTimeoutId !== undefined) {
+        window.clearTimeout(closeTimeoutId);
+        closeTimeoutId = undefined;
+    }
+
+    transitionState.value = 'is-opening';
+
+    if (!dialogEl.value?.open) {
+        if (props.seamless) {
+            dialogEl.value?.show();
+        } else {
+            dialogEl.value?.showModal();
+        }
+    }
+
+    if (!props.seamless) {
+        document.documentElement.style.overflow = 'hidden';
+    }
+
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            if (transitionState.value === 'is-opening') {
+                transitionState.value = '';
+            }
+        });
+    });
+};
+
+const startClose = () => {
+    if (transitionState.value === 'is-closing') return;
+    transitionState.value = 'is-closing';
+    closeTimeoutId = window.setTimeout(finishClose, 250);
+};
 
 onMounted(() => {
     if (flg.value) {
-        dialogEl.value?.show();
-        if (!props.seamless) document.documentElement.style.overflow = 'hidden';
+        open();
     }
 });
 
@@ -121,34 +140,34 @@ watch(
     () => flg.value,
     (newFlg) => {
         if (newFlg) {
-            dialogEl.value?.show();
-            if (!props.seamless) document.documentElement.style.overflow = 'hidden';
+            open();
         } else {
-            dialogEl.value?.close();
-            document.documentElement.style.overflow = '';
+            startClose();
         }
     }
 );
 
-// Accordion枠外制御
-const onClose = async () => {
-    flg.value = false;
-    await onClosed();
-};
-const onClosed = async () => {
-    if (isShowing.value) {
-        await sleep(100);
-        onClosed();
-    } else {
-        emit('closed');
+const onCancel = () => {
+    if (!props.persistent) {
+        flg.value = false;
     }
 };
-const { vOutsideClick } = useOutsideClick();
-const onOutsideClick = computed(() => ({
-    handler: onClose,
-    isActive: flg.value && !props.persistent && !props.seamless,
-    ignore: props.outsideClickIgnore
-}));
+
+const onBackdropClick = (e: MouseEvent) => {
+    if (e.target === dialogEl.value && !props.persistent && !props.seamless) {
+        flg.value = false;
+    }
+};
+
+onBeforeUnmount(() => {
+    if (closeTimeoutId !== undefined) {
+        window.clearTimeout(closeTimeoutId);
+    }
+    if (dialogEl.value?.open) {
+        dialogEl.value.close();
+    }
+    document.documentElement.style.overflow = '';
+});
 
 const slots = useSlots();
 const hasSlot = (name: string) => {
@@ -158,26 +177,16 @@ const hasSlot = (name: string) => {
 
 <template>
     <TeleportRoot>
-    <OpacityTransition
-        @transition-start="transitioning = true"
-        @transition-end="transitioning = false"
-    >
-        <div v-show="flg" class="component-dialog" :class="{ 'is-seamless': seamless }">
-            <component
-                :is="TransitionComponent"
-                :from="resolvedTransitionFrom"
-                @transition-start="transitioning = true"
-                @transition-end="transitioning = false"
-            >
-                <component
-                    :is="frameComponent"
-                    v-show="flg"
-                    class="dialog-frame"
-                    :class="[position]"
-                    v-outside-click="onOutsideClick"
-                    >
-                    <dialog
-                        ref="dialogEl"
+        <dialog
+            ref="dialogEl"
+            class="component-dialog"
+            :class="[transitionState, transitionFromClass, { 'is-seamless': seamless }]"
+            @click="onBackdropClick"
+            @cancel.prevent="onCancel"
+        >
+            <div class="dialog-panel" :class="[position]" @click.stop>
+                <component :is="frameComponent" class="dialog-frame">
+                    <div
                         class="dialog"
                         :class="[variant, size, shape, { 'is-center': center }]"
                     >
@@ -196,11 +205,10 @@ const hasSlot = (name: string) => {
                         <div v-if="hasSlot('footer')" class="footer">
                             <slot name="footer" />
                         </div>
-                    </dialog>
+                    </div>
                 </component>
-            </component>
-        </div>
-    </OpacityTransition>
+            </div>
+        </dialog>
     </TeleportRoot>
 </template>
 
@@ -208,26 +216,78 @@ const hasSlot = (name: string) => {
 .component-dialog {
     position: fixed;
     inset: 0;
-    z-index: 10;
-    pointer-events: none;
-    &:not(.is-seamless) {
-        &::before {
-            position: fixed;
-            inset: 0;
-            z-index: -1;
-            width: 100vw;
-            pointer-events: initial;
-            content: '';
-            background-color: var(--color-shadow-alpha);
-        }
+    width: 100%;
+    max-width: none;
+    height: 100%;
+    max-height: none;
+    padding: 0;
+    margin: 0;
+    overflow: visible;
+    color: inherit;
+    outline: none;
+    background: transparent;
+    border: none;
+    &::backdrop {
+        background-color: var(--color-shadow-alpha);
+        opacity: 1;
+        transition: opacity 0.2s ease-in-out;
     }
-    .dialog-frame {
-        position: fixed;
-        width: fit-content;
-        height: fit-content;
-        margin: auto;
+    &.is-opening::backdrop,
+    &.is-closing::backdrop {
+        opacity: 0;
+    }
+    &.is-seamless {
+        z-index: 10;
+        pointer-events: none;
     }
 }
+
+.dialog-panel {
+    position: fixed;
+    inset: 0;
+    width: fit-content;
+    height: fit-content;
+    margin: auto;
+    pointer-events: auto;
+    opacity: 1;
+    transform: translate(0, 0);
+    transition:
+        opacity 0.2s ease-in-out,
+        transform 0.2s ease-in-out;
+}
+
+/* ▼ transition ▼ */
+
+.is-opening .dialog-panel,
+.is-closing .dialog-panel {
+    opacity: 0;
+}
+
+.is-opening.from-top .dialog-panel,
+.is-closing.from-top .dialog-panel {
+    opacity: 0;
+    transform: translateY(-100%);
+}
+
+.is-opening.from-right .dialog-panel,
+.is-closing.from-right .dialog-panel {
+    opacity: 0;
+    transform: translateX(100%);
+}
+
+.is-opening.from-bottom .dialog-panel,
+.is-closing.from-bottom .dialog-panel {
+    opacity: 0;
+    transform: translateY(100%);
+}
+
+.is-opening.from-left .dialog-panel,
+.is-closing.from-left .dialog-panel {
+    opacity: 0;
+    transform: translateX(-100vw);
+}
+
+/* ▲ transition ▲ */
 
 .dialog {
     position: relative;
@@ -241,7 +301,6 @@ const hasSlot = (name: string) => {
     padding: var(--space-sm) 0;
     margin: auto;
     color: var(--color-text-primary);
-    pointer-events: initial;
     background-color: var(--color-bg-primary);
     border: 1px solid;
     border-color: var(--c-dialog-border-color);
@@ -387,29 +446,37 @@ const hasSlot = (name: string) => {
 .top {
     inset: 0;
     bottom: auto;
-    border-top: 0;
-    border-radius: 0 0 var(--c-dialog-border-radius) var(--c-dialog-border-radius);
+    .dialog {
+        border-top: 0;
+        border-radius: 0 0 var(--c-dialog-border-radius) var(--c-dialog-border-radius);
+    }
 }
 
 .right {
     inset: 0;
     left: auto;
-    border-right: 0;
-    border-radius: var(--c-dialog-border-radius) 0 0 var(--c-dialog-border-radius);
+    .dialog {
+        border-right: 0;
+        border-radius: var(--c-dialog-border-radius) 0 0 var(--c-dialog-border-radius);
+    }
 }
 
 .bottom {
     inset: 0;
     top: auto;
-    border-bottom: 0;
-    border-radius: var(--c-dialog-border-radius) var(--c-dialog-border-radius) 0 0;
+    .dialog {
+        border-bottom: 0;
+        border-radius: var(--c-dialog-border-radius) var(--c-dialog-border-radius) 0 0;
+    }
 }
 
 .left {
     inset: 0;
     right: auto;
-    border-left: 0;
-    border-radius: 0 var(--c-dialog-border-radius) var(--c-dialog-border-radius) 0;
+    .dialog {
+        border-left: 0;
+        border-radius: 0 var(--c-dialog-border-radius) var(--c-dialog-border-radius) 0;
+    }
 }
 
 /* ▲ position ▲ */

--- a/src/components/feedback/Modal.vue
+++ b/src/components/feedback/Modal.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
-import { ref, computed, watch, markRaw, onMounted, type Component } from 'vue';
+import { ref, computed, watch, onMounted, onBeforeUnmount, type Component } from 'vue';
 import TeleportRoot from '@/components/inner-parts/TeleportRoot.vue';
-import OpacityTransition from '@/components/inner-parts/OpacityTransition.vue';
-import TranslateTransition from '@/components/inner-parts/TranslateTransition.vue';
 import Button from '@/components/basic/Button.vue';
-import { sleep } from '@/assets/ts';
 import { X as IconX } from 'lucide-vue-next';
-import useOutsideClick from '@/directives/useOutsideClick';
 
 const flg = defineModel<boolean>({ default: false });
 const props = withDefaults(
@@ -40,10 +36,6 @@ const props = withDefaults(
          */
         persistent?: boolean;
         /**
-         * 枠外クリック除外要素
-         */
-        outsideClickIgnore?: (Element | string)[];
-        /**
          * フレーム装飾用コンポーネント
          */
         frameComponent?: Component | string;
@@ -54,10 +46,8 @@ const props = withDefaults(
         shape: 'normal',
         transitionFrom: 'opacity',
         title: '',
-        scroll: false,
         center: false,
         persistent: false,
-        outsideClickIgnore: () => ['button', 'dialog'],
         frameComponent: 'div'
     }
 );
@@ -68,38 +58,65 @@ const emit = defineEmits<{
     closed: [];
 }>();
 
-// transition状態
-const TransitionComponent = markRaw(
-    props.transitionFrom === 'opacity' ? OpacityTransition : TranslateTransition
-);
-const transitioning = ref(false);
-const isShowing = computed(() => {
-    if (flg.value) {
-        return true;
-    } else {
-        return transitioning.value;
-    }
-});
-const resolvedTransitionFrom = computed(() => {
-    if (props.transitionFrom === 'top') {
-        return 'top-rebound';
-    } else if (props.transitionFrom === 'right') {
-        return 'right-rebound';
-    } else if (props.transitionFrom === 'bottom') {
-        return 'bottom-rebound';
-    } else if (props.transitionFrom === 'left') {
-        return 'left-rebound';
-    } else {
-        return undefined;
-    }
+const transitionState = ref<'is-opening' | 'is-closing' | ''>('');
+const transitionFromClass = computed(() => {
+    if (props.transitionFrom === 'top') return 'from-top';
+    if (props.transitionFrom === 'right') return 'from-right';
+    if (props.transitionFrom === 'bottom') return 'from-bottom';
+    if (props.transitionFrom === 'left') return 'from-left';
+    return '';
 });
 
 const dialogEl = ref<HTMLDialogElement | null>(null);
+let closeTimeoutId: number | undefined;
+
+const finishClose = () => {
+    if (closeTimeoutId !== undefined) {
+        window.clearTimeout(closeTimeoutId);
+        closeTimeoutId = undefined;
+    }
+    transitionState.value = '';
+    dialogEl.value?.close();
+    document.documentElement.style.overflow = '';
+    emit('closed');
+};
+
+const open = () => {
+    if (closeTimeoutId !== undefined) {
+        window.clearTimeout(closeTimeoutId);
+        closeTimeoutId = undefined;
+    }
+
+    transitionState.value = 'is-opening';
+
+    if (!dialogEl.value?.open) {
+        dialogEl.value?.showModal();
+    }
+
+    document.documentElement.style.overflow = 'hidden';
+
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            if (transitionState.value === 'is-opening') {
+                transitionState.value = '';
+            }
+        });
+    });
+};
+
+const startClose = () => {
+    if (transitionState.value === 'is-closing') return;
+    transitionState.value = 'is-closing';
+    closeTimeoutId = window.setTimeout(finishClose, 250);
+};
+
+const onClose = () => {
+    flg.value = false;
+};
 
 onMounted(() => {
     if (flg.value) {
-        dialogEl.value?.show();
-        document.documentElement.style.overflow = 'hidden';
+        open();
     }
 });
 
@@ -107,57 +124,48 @@ watch(
     () => flg.value,
     (newFlg) => {
         if (newFlg) {
-            dialogEl.value?.show();
-            document.documentElement.style.overflow = 'hidden';
+            open();
         } else {
-            dialogEl.value?.close();
-            document.documentElement.style.overflow = '';
+            startClose();
         }
     }
 );
 
-// Accordion枠外制御
-const onClose = async () => {
-    flg.value = false;
-    await onClosed();
-};
-const onClosed = async () => {
-    if (isShowing.value) {
-        await sleep(100);
-        onClosed();
-    } else {
-        emit('closed');
+const onCancel = () => {
+    if (!props.persistent) {
+        flg.value = false;
     }
 };
-const { vOutsideClick } = useOutsideClick();
-const onOutsideClick = computed(() => ({
-    handler: onClose,
-    isActive: flg.value && !props.persistent,
-    ignore: props.outsideClickIgnore
-}));
+
+const onBackdropClick = (e: MouseEvent) => {
+    if (e.target === dialogEl.value && !props.persistent) {
+        flg.value = false;
+    }
+};
+
+onBeforeUnmount(() => {
+    if (closeTimeoutId !== undefined) {
+        window.clearTimeout(closeTimeoutId);
+    }
+    if (dialogEl.value?.open) {
+        dialogEl.value.close();
+    }
+    document.documentElement.style.overflow = '';
+});
 </script>
 
 <template>
     <TeleportRoot>
-    <OpacityTransition
-        @transition-start="transitioning = true"
-        @transition-end="transitioning = false"
-    >
-        <div v-show="flg" class="component-modal">
-            <component
-                :is="TransitionComponent"
-                :from="resolvedTransitionFrom"
-                @transition-start="transitioning = true"
-                @transition-end="transitioning = false"
-            >
-                <component
-                    :is="frameComponent"
-                    v-show="flg"
-                    class="modal-frame"
-                    v-outside-click="onOutsideClick"
-                >
-                    <dialog
-                        ref="dialogEl"
+        <dialog
+            ref="dialogEl"
+            class="component-modal"
+            :class="[transitionState, transitionFromClass]"
+            @click="onBackdropClick"
+            @cancel.prevent="onCancel"
+        >
+            <div class="modal-panel" @click.stop>
+                <component :is="frameComponent" class="modal-frame">
+                    <div
                         class="modal"
                         :class="[size, shape, { 'is-center': center, 'is-full-size-by-sp': isFullSizeBySp }]"
                     >
@@ -170,11 +178,10 @@ const onOutsideClick = computed(() => ({
                                 </div>
                             </div>
                         </div>
-                    </dialog>
+                    </div>
                 </component>
-            </component>
-        </div>
-    </OpacityTransition>
+            </div>
+        </dialog>
     </TeleportRoot>
 </template>
 
@@ -182,24 +189,73 @@ const onOutsideClick = computed(() => ({
 .component-modal {
     position: fixed;
     inset: 0;
-    z-index: 10;
-    pointer-events: none;
-    &::before {
-        position: fixed;
-        inset: 0;
-        z-index: -1;
-        pointer-events: initial;
-        content: '';
+    width: 100%;
+    max-width: none;
+    height: 100%;
+    max-height: none;
+    padding: 0;
+    margin: 0;
+    overflow: visible;
+    color: inherit;
+    outline: none;
+    background: transparent;
+    border: none;
+    &::backdrop {
         background-color: var(--color-shadow-alpha);
+        opacity: 1;
+        transition: opacity 0.2s ease-in-out;
     }
-    .modal-frame {
-        position: fixed;
-        inset: 0;
-        width: fit-content;
-        height: fit-content;
-        margin: auto;
+    &.is-opening::backdrop,
+    &.is-closing::backdrop {
+        opacity: 0;
     }
 }
+
+.modal-panel {
+    position: fixed;
+    inset: 0;
+    width: fit-content;
+    height: fit-content;
+    margin: auto;
+    opacity: 1;
+    transform: translate(0, 0);
+    transition:
+        opacity 0.2s ease-in-out,
+        transform 0.2s ease-in-out;
+}
+
+/* ▼ transition ▼ */
+
+.is-opening .modal-panel,
+.is-closing .modal-panel {
+    opacity: 0;
+}
+
+.is-opening.from-top .modal-panel,
+.is-closing.from-top .modal-panel {
+    opacity: 0;
+    transform: translateY(-100%);
+}
+
+.is-opening.from-right .modal-panel,
+.is-closing.from-right .modal-panel {
+    opacity: 0;
+    transform: translateX(100%);
+}
+
+.is-opening.from-bottom .modal-panel,
+.is-closing.from-bottom .modal-panel {
+    opacity: 0;
+    transform: translateY(100%);
+}
+
+.is-opening.from-left .modal-panel,
+.is-closing.from-left .modal-panel {
+    opacity: 0;
+    transform: translateX(-100vw);
+}
+
+/* ▲ transition ▲ */
 
 .modal {
     position: relative;
@@ -214,7 +270,6 @@ const onOutsideClick = computed(() => ({
     padding: var(--space-sm) 0;
     margin: auto;
     color: var(--color-text-primary);
-    pointer-events: initial;
     background-color: var(--color-bg-primary);
     border: 1px solid;
     border-color: var(--color-border);

--- a/src/test/components/feedback/Dialog.spec.ts
+++ b/src/test/components/feedback/Dialog.spec.ts
@@ -2,22 +2,23 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import Dialog from '@/components/feedback/Dialog.vue';
-import TranslateTransition from '@/components/inner-parts/TranslateTransition.vue';
 
 describe('Dialog', () => {
     afterEach(() => {
         vi.useRealTimers();
-    });
-    it('v-model が true のとき dialog が表示される', () => {
-        const wrapper = mount(Dialog, { props: { modelValue: true } });
-        const el = wrapper.find('.component-dialog').element as HTMLElement;
-        expect(el.style.display).not.toBe('none');
+        document.documentElement.style.overflow = '';
     });
 
-    it('v-model が false のとき dialog が非表示になる', () => {
+    it('v-model が true のとき dialog が open になる', () => {
+        const wrapper = mount(Dialog, { props: { modelValue: true } });
+        const dialog = wrapper.find('.component-dialog').element as HTMLDialogElement;
+        expect(dialog.open).toBe(true);
+    });
+
+    it('v-model が false のとき dialog が open にならない', () => {
         const wrapper = mount(Dialog, { props: { modelValue: false } });
-        const el = wrapper.find('.component-dialog').element as HTMLElement;
-        expect(el.style.display).toBe('none');
+        const dialog = wrapper.find('.component-dialog').element as HTMLDialogElement;
+        expect(dialog.open).toBe(false);
     });
 
     it('title が指定されたとき .title が表示される', () => {
@@ -50,29 +51,28 @@ describe('Dialog', () => {
     it('footer slot が表示される', () => {
         const wrapper = mount(Dialog, {
             props: { modelValue: true },
-            slots: { footer: '<button class="ok-btn">OK</button>' }
+            slots: { footer: '<button>OK</button>' }
         });
-        expect(wrapper.find('.ok-btn').exists()).toBe(true);
-    });
-
-    it('center prop のとき is-center クラスが付く', () => {
-        const wrapper = mount(Dialog, { props: { modelValue: true, center: true } });
-        expect(wrapper.find('.dialog').classes()).toContain('is-center');
-    });
-
-    it('position prop がクラスに反映される', () => {
-        const wrapper = mount(Dialog, { props: { modelValue: true, position: 'top' } });
-        expect(wrapper.find('.dialog-frame').classes()).toContain('top');
+        expect(wrapper.find('.footer').exists()).toBe(true);
     });
 
     it.each([
-        ['top', 'top-rebound'],
-        ['right', 'right-rebound'],
-        ['bottom', 'bottom-rebound'],
-        ['left', 'left-rebound']
-    ])('transitionFrom="%s" が TranslateTransition に反映される', (transitionFrom, expectedFrom) => {
+        ['top', 'from-top'],
+        ['right', 'from-right'],
+        ['bottom', 'from-bottom'],
+        ['left', 'from-left']
+    ])('transitionFrom="%s" が dialog に %s クラスとして反映される', (transitionFrom, expectedClass) => {
         const wrapper = mount(Dialog, { props: { modelValue: true, transitionFrom: transitionFrom as any } });
-        expect(wrapper.findComponent(TranslateTransition).props('from')).toBe(expectedFrom);
+        expect(wrapper.find('.component-dialog').classes()).toContain(expectedClass);
+    });
+
+    it('transitionFrom が opacity のとき方向クラスが付かない', () => {
+        const wrapper = mount(Dialog, { props: { modelValue: true, transitionFrom: 'opacity' } });
+        const classes = wrapper.find('.component-dialog').classes();
+        expect(classes).not.toContain('from-top');
+        expect(classes).not.toContain('from-right');
+        expect(classes).not.toContain('from-bottom');
+        expect(classes).not.toContain('from-left');
     });
 
     it('seamless prop のとき is-seamless クラスが付く', () => {
@@ -80,7 +80,24 @@ describe('Dialog', () => {
         expect(wrapper.find('.component-dialog').classes()).toContain('is-seamless');
     });
 
-    it('外側クリックで closed イベントが発火する', async () => {
+    it('seamless のとき show() が使われる', () => {
+        const showSpy = vi.spyOn(HTMLDialogElement.prototype, 'show');
+        const showModalSpy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+        mount(Dialog, { props: { modelValue: true, seamless: true } });
+        expect(showSpy).toHaveBeenCalled();
+        expect(showModalSpy).not.toHaveBeenCalled();
+        showSpy.mockRestore();
+        showModalSpy.mockRestore();
+    });
+
+    it('seamless でないとき showModal() が使われる', () => {
+        const showModalSpy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+        mount(Dialog, { props: { modelValue: true } });
+        expect(showModalSpy).toHaveBeenCalled();
+        showModalSpy.mockRestore();
+    });
+
+    it('backdrop クリックで closed イベントが発火する', async () => {
         vi.useFakeTimers();
         const wrapper = mount(Dialog, {
             props: {
@@ -88,26 +105,169 @@ describe('Dialog', () => {
                 'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
             }
         });
-        document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        await vi.runAllTimersAsync();
+        const dialog = wrapper.find('.component-dialog');
+        await dialog.trigger('click');
+        await vi.advanceTimersByTimeAsync(300);
         await nextTick();
         expect(wrapper.emitted('closed')).toBeTruthy();
+    });
+
+    it('persistent のとき backdrop クリックで閉じない', async () => {
+        const wrapper = mount(Dialog, {
+            props: {
+                modelValue: true,
+                persistent: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const dialog = wrapper.find('.component-dialog');
+        await dialog.trigger('click');
+        expect(wrapper.props('modelValue')).toBe(true);
+    });
+
+    it('persistent のとき cancel イベントで閉じない', async () => {
+        const wrapper = mount(Dialog, {
+            props: {
+                modelValue: true,
+                persistent: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const dialog = wrapper.find('.component-dialog');
+        await dialog.trigger('cancel');
+        expect(wrapper.props('modelValue')).toBe(true);
+    });
+
+    it('persistent でないとき cancel で閉じる', async () => {
+        vi.useFakeTimers();
+        const wrapper = mount(Dialog, {
+            props: {
+                modelValue: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const dialog = wrapper.find('.component-dialog');
+        await dialog.trigger('cancel');
+        expect(wrapper.props('modelValue')).toBe(false);
+        await vi.advanceTimersByTimeAsync(300);
+        await nextTick();
+        expect(wrapper.emitted('closed')).toBeTruthy();
+    });
+
+    it('seamless のとき backdrop クリックで閉じない', async () => {
+        const wrapper = mount(Dialog, {
+            props: {
+                modelValue: true,
+                seamless: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const dialog = wrapper.find('.component-dialog');
+        await dialog.trigger('click');
+        expect(wrapper.props('modelValue')).toBe(true);
     });
 
     it.each([
         ['info'],
         ['success'],
-        ['warning']
+        ['warning'],
+        ['danger']
     ])('variant="%s" のときクラスが付く', (variant) => {
         const wrapper = mount(Dialog, { props: { modelValue: true, variant: variant as any } });
         expect(wrapper.find('.dialog').classes()).toContain(variant);
+    });
+
+    it.each([
+        ['center'],
+        ['top'],
+        ['right'],
+        ['bottom'],
+        ['left']
+    ])('position="%s" のときクラスが dialog-panel に付く', (position) => {
+        const wrapper = mount(Dialog, { props: { modelValue: true, position: position as any } });
+        expect(wrapper.find('.dialog-panel').classes()).toContain(position);
+    });
+
+    it('center prop のとき is-center クラスが付く', () => {
+        const wrapper = mount(Dialog, { props: { modelValue: true, center: true } });
+        expect(wrapper.find('.dialog').classes()).toContain('is-center');
     });
 
     it('v-model が false → true に変わると overflow が hidden になる', async () => {
         const wrapper = mount(Dialog, { props: { modelValue: false } });
         await wrapper.setProps({ modelValue: true });
         expect(document.documentElement.style.overflow).toBe('hidden');
-        // cleanup
-        document.documentElement.style.overflow = '';
+    });
+
+    it('seamless のとき overflow が hidden にならない', () => {
+        mount(Dialog, { props: { modelValue: true, seamless: true } });
+        expect(document.documentElement.style.overflow).not.toBe('hidden');
+    });
+
+    it('v-model が true → false で overflow が解除される', async () => {
+        vi.useFakeTimers();
+        const wrapper = mount(Dialog, {
+            props: {
+                modelValue: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        expect(document.documentElement.style.overflow).toBe('hidden');
+        await wrapper.setProps({ modelValue: false });
+        await vi.advanceTimersByTimeAsync(300);
+        await nextTick();
+        expect(document.documentElement.style.overflow).toBe('');
+    });
+
+    it('unmount 時に overflow がリセットされる', () => {
+        const wrapper = mount(Dialog, { props: { modelValue: true } });
+        expect(document.documentElement.style.overflow).toBe('hidden');
+        wrapper.unmount();
+        expect(document.documentElement.style.overflow).toBe('');
+    });
+
+    it('dialog-panel のクリックは backdrop クリックとして扱われない', async () => {
+        const wrapper = mount(Dialog, {
+            props: {
+                modelValue: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        await wrapper.find('.dialog-panel').trigger('click');
+        expect(wrapper.props('modelValue')).toBe(true);
+    });
+
+    it('閉じるアニメーション中に開くと close がキャンセルされる', async () => {
+        vi.useFakeTimers();
+        const wrapper = mount(Dialog, {
+            props: {
+                modelValue: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const dialog = wrapper.find('.component-dialog').element as HTMLDialogElement;
+        await wrapper.setProps({ modelValue: false });
+        await wrapper.setProps({ modelValue: true });
+        await vi.advanceTimersByTimeAsync(300);
+        await nextTick();
+        expect(wrapper.emitted('closed')).toBeFalsy();
+        expect(dialog.open).toBe(true);
+    });
+
+    it('二重 close が防がれる', async () => {
+        vi.useFakeTimers();
+        const wrapper = mount(Dialog, {
+            props: {
+                modelValue: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        await wrapper.setProps({ modelValue: false });
+        await wrapper.setProps({ modelValue: false });
+        await vi.advanceTimersByTimeAsync(300);
+        await nextTick();
+        const closedEvents = wrapper.emitted('closed');
+        expect(closedEvents).toBeTruthy();
+        expect(closedEvents!.length).toBe(1);
     });
 });

--- a/src/test/components/feedback/Modal.spec.ts
+++ b/src/test/components/feedback/Modal.spec.ts
@@ -2,22 +2,23 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import Modal from '@/components/feedback/Modal.vue';
-import TranslateTransition from '@/components/inner-parts/TranslateTransition.vue';
 
 describe('Modal', () => {
     afterEach(() => {
         vi.useRealTimers();
-    });
-    it('v-model が true のとき modal が表示される', () => {
-        const wrapper = mount(Modal, { props: { modelValue: true } });
-        const el = wrapper.find('.component-modal').element as HTMLElement;
-        expect(el.style.display).not.toBe('none');
+        document.documentElement.style.overflow = '';
     });
 
-    it('v-model が false のとき modal が非表示になる', () => {
+    it('v-model が true のとき modal が open になる', () => {
+        const wrapper = mount(Modal, { props: { modelValue: true } });
+        const dialog = wrapper.find('.component-modal').element as HTMLDialogElement;
+        expect(dialog.open).toBe(true);
+    });
+
+    it('v-model が false のとき modal が open にならない', () => {
         const wrapper = mount(Modal, { props: { modelValue: false } });
-        const el = wrapper.find('.component-modal').element as HTMLElement;
-        expect(el.style.display).toBe('none');
+        const dialog = wrapper.find('.component-modal').element as HTMLDialogElement;
+        expect(dialog.open).toBe(false);
     });
 
     it('title が指定されたとき .title が表示される', () => {
@@ -57,23 +58,6 @@ describe('Modal', () => {
         expect(wrapper.props('modelValue')).toBe(false);
     });
 
-    it('v-model が false → true に変わると overflow が hidden になる', async () => {
-        const wrapper = mount(Modal, { props: { modelValue: false } });
-        await wrapper.setProps({ modelValue: true });
-        expect(document.documentElement.style.overflow).toBe('hidden');
-        document.documentElement.style.overflow = '';
-    });
-
-    it.each([
-        ['top', 'top-rebound'],
-        ['right', 'right-rebound'],
-        ['bottom', 'bottom-rebound'],
-        ['left', 'left-rebound']
-    ])('transitionFrom="%s" が TranslateTransition に反映される', (transitionFrom, expectedFrom) => {
-        const wrapper = mount(Modal, { props: { modelValue: true, transitionFrom: transitionFrom as any } });
-        expect(wrapper.findComponent(TranslateTransition).props('from')).toBe(expectedFrom);
-    });
-
     it('閉じるボタンクリックで closed イベントが発火する', async () => {
         vi.useFakeTimers();
         const wrapper = mount(Modal, {
@@ -83,8 +67,157 @@ describe('Modal', () => {
             }
         });
         await wrapper.find('.closeable-box').trigger('click');
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(300);
         await nextTick();
         expect(wrapper.emitted('closed')).toBeTruthy();
+    });
+
+    it.each([
+        ['top', 'from-top'],
+        ['right', 'from-right'],
+        ['bottom', 'from-bottom'],
+        ['left', 'from-left']
+    ])('transitionFrom="%s" が modal に %s クラスとして反映される', (transitionFrom, expectedClass) => {
+        const wrapper = mount(Modal, { props: { modelValue: true, transitionFrom: transitionFrom as any } });
+        expect(wrapper.find('.component-modal').classes()).toContain(expectedClass);
+    });
+
+    it('transitionFrom が opacity のとき方向クラスが付かない', () => {
+        const wrapper = mount(Modal, { props: { modelValue: true, transitionFrom: 'opacity' } });
+        const classes = wrapper.find('.component-modal').classes();
+        expect(classes).not.toContain('from-top');
+        expect(classes).not.toContain('from-right');
+        expect(classes).not.toContain('from-bottom');
+        expect(classes).not.toContain('from-left');
+    });
+
+    it('backdrop クリックで closed イベントが発火する', async () => {
+        vi.useFakeTimers();
+        const wrapper = mount(Modal, {
+            props: {
+                modelValue: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const dialog = wrapper.find('.component-modal');
+        await dialog.trigger('click');
+        await vi.advanceTimersByTimeAsync(300);
+        await nextTick();
+        expect(wrapper.emitted('closed')).toBeTruthy();
+    });
+
+    it('persistent のとき backdrop クリックで閉じない', async () => {
+        const wrapper = mount(Modal, {
+            props: {
+                modelValue: true,
+                persistent: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const dialog = wrapper.find('.component-modal');
+        await dialog.trigger('click');
+        expect(wrapper.props('modelValue')).toBe(true);
+    });
+
+    it('persistent のとき cancel イベントで閉じない', async () => {
+        const wrapper = mount(Modal, {
+            props: {
+                modelValue: true,
+                persistent: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const dialog = wrapper.find('.component-modal');
+        await dialog.trigger('cancel');
+        expect(wrapper.props('modelValue')).toBe(true);
+    });
+
+    it('persistent でないとき cancel で閉じる', async () => {
+        vi.useFakeTimers();
+        const wrapper = mount(Modal, {
+            props: {
+                modelValue: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const dialog = wrapper.find('.component-modal');
+        await dialog.trigger('cancel');
+        expect(wrapper.props('modelValue')).toBe(false);
+        await vi.advanceTimersByTimeAsync(300);
+        await nextTick();
+        expect(wrapper.emitted('closed')).toBeTruthy();
+    });
+
+    it('center prop のとき is-center クラスが付く', () => {
+        const wrapper = mount(Modal, { props: { modelValue: true, center: true } });
+        expect(wrapper.find('.modal').classes()).toContain('is-center');
+    });
+
+    it('isFullSizeBySp prop のとき is-full-size-by-sp クラスが付く', () => {
+        const wrapper = mount(Modal, { props: { modelValue: true, isFullSizeBySp: true } });
+        expect(wrapper.find('.modal').classes()).toContain('is-full-size-by-sp');
+    });
+
+    it('v-model が false → true に変わると overflow が hidden になる', async () => {
+        const wrapper = mount(Modal, { props: { modelValue: false } });
+        await wrapper.setProps({ modelValue: true });
+        expect(document.documentElement.style.overflow).toBe('hidden');
+    });
+
+    it('v-model が true → false で overflow が解除される', async () => {
+        vi.useFakeTimers();
+        const wrapper = mount(Modal, {
+            props: {
+                modelValue: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        expect(document.documentElement.style.overflow).toBe('hidden');
+        await wrapper.setProps({ modelValue: false });
+        await vi.advanceTimersByTimeAsync(300);
+        await nextTick();
+        expect(document.documentElement.style.overflow).toBe('');
+    });
+
+    it('unmount 時に overflow がリセットされる', () => {
+        const wrapper = mount(Modal, { props: { modelValue: true } });
+        expect(document.documentElement.style.overflow).toBe('hidden');
+        wrapper.unmount();
+        expect(document.documentElement.style.overflow).toBe('');
+    });
+
+    it('modal-panel のクリックは backdrop クリックとして扱われない', async () => {
+        const wrapper = mount(Modal, {
+            props: {
+                modelValue: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        await wrapper.find('.modal-panel').trigger('click');
+        expect(wrapper.props('modelValue')).toBe(true);
+    });
+
+    it('showModal() が使用される', () => {
+        const showModalSpy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+        mount(Modal, { props: { modelValue: true } });
+        expect(showModalSpy).toHaveBeenCalled();
+        showModalSpy.mockRestore();
+    });
+
+    it('閉じるアニメーション中に開くと close がキャンセルされる', async () => {
+        vi.useFakeTimers();
+        const wrapper = mount(Modal, {
+            props: {
+                modelValue: true,
+                'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
+            }
+        });
+        const dialog = wrapper.find('.component-modal').element as HTMLDialogElement;
+        await wrapper.setProps({ modelValue: false });
+        await wrapper.setProps({ modelValue: true });
+        await vi.advanceTimersByTimeAsync(300);
+        await nextTick();
+        expect(wrapper.emitted('closed')).toBeFalsy();
+        expect(dialog.open).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- Dialog/Modalの`show()`を`showModal()`に切り替え、ブラウザネイティブのフォーカストラップ・Escapeキー対応・`::backdrop`疑似要素・top layerを活用
- `OpacityTransition`/`TranslateTransition`ラッパーをCSSクラスベースのトランジション（`is-opening`/`is-closing`）に置換
- `outsideClickIgnore` propを削除（破壊的変更）— `showModal()`のbackdropが外側クリックを遮断するため不要
- Dialogのseamlessモードは`show()`を使用（非モーダル動作を維持）

## 破壊的変更
| 変更 | 影響 |
|------|------|
| `outsideClickIgnore` prop削除 | showModalのbackdropが相互作用を遮断するため不要 |
| `::before`→`::backdrop` | カスタムCSSで`::before`を上書きしていた場合は`::backdrop`に変更が必要 |
| top layer配置 | z-indexでDialog/Modalの上に要素を重ねていた場合は動作が変わる |

## 技術詳細
- `<dialog>`を最外層に昇格し、CSSクラスベースのトランジションを直接適用
- バックドロップクリック検出: `@click`（dialog）+ `@click.stop`（panel）で代替
- `cancel`イベントで Escape キーを処理（`persistent`時は`preventDefault()`）
- 2フェーズclose: `is-closing`クラス→CSS transition→`setTimeout(250ms)`フォールバック→`dialog.close()`
- positionのborder調整を`.dialog-frame`から`.dialog`に移動（旧コードではborderのない要素に適用されていたバグを修正）

## Test plan
- [x] `pnpm test:run` — 767テスト全パス
- [x] `pnpm lint:fix` — パス
- [x] `pnpm vue-tsc --noEmit` — パス
- [x] `pnpm build` — パス
- [ ] Playground 3環境（Vue/Nuxt3/Nuxt4）での動作確認

closes #845

Generated with [Claude Code](https://claude.ai/code)