### PR TITLE
fix: ライブラリビルドのミニファイを無効化し識別子重複エラーを解消

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,7 @@ const externalRegexps = externalPackages.map(
 
 export default defineConfig({
     build: {
+        minify: false,
         lib: {
             entry: resolve(__dirname, './src/index.ts'),
             name: 'minazuki-ui',


### PR DESCRIPTION
## 概要

- `vite.config.ts` の `build` に `minify: false` を追加し、ライブラリの ESM/UMD 出力からミニファイを除去
- esbuild ミニファイによる1文字変数名が Nuxt バンドラーの再処理時に `Identifier "h" has already been declared` エラーを引き起こしていた構造的問題を解消

## 検証結果

- `pnpm build` — ライブラリビルド成功、`dist/` の変数名が元のソースコード通りに出力されることを確認
- `playground/nuxt3 pnpm build` — 成功
- `playground/nuxt4 pnpm build` — 成功
- lint / type-check — パス

Closes #854

Generated with [Claude Code](https://claude.ai/code)