### PR TITLE
fix: overrideThemeでリアクティブプロキシのstructuredCloneエラーを修正

### DIFF
--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -5,7 +5,7 @@
  * ==================================================
  */
 
-import { ref, shallowRef, watch } from 'vue';
+import { ref, shallowRef, toRaw, watch } from 'vue';
 import { useHead } from '@unhead/vue';
 import { toKebabCase } from '@/assets/ts/formatter';
 import {
@@ -348,8 +348,8 @@ function assignDefined<T extends object>(target: T, source: Partial<T>): void {
 }
 
 const overrideTheme = (overrides: MiThemeOverride) => {
-    const raw: MiThemeOverride = structuredClone(overrides);
-    const config = structuredClone(themeConfig.value);
+    const raw: MiThemeOverride = structuredClone(toRaw(overrides));
+    const config = structuredClone(toRaw(themeConfig.value));
 
     if (raw.primitives) {
         if (raw.primitives.hues) {


### PR DESCRIPTION
## 概要

Nuxt 3/4 playground で `overrideTheme` 内の `structuredClone` が `runtimeConfig` 由来のリアクティブプロキシオブジェクトを複製できず、アプリ初期化時に `DataCloneError` が発生する問題を修正。

## 変更内容

- `src/composables/useTheme.ts` の `overrideTheme` 関数で、`structuredClone` の前に Vue の `toRaw()` を適用
- `overrides`（外部から渡されるテーマ設定）と `themeConfig.value`（内部状態）の両方に対応
- `toRaw()` は非リアクティブな値に対しては no-op のため、既存の Vue playground パスへの副作用なし

## 原因

1. Nuxt module が `nuxt.config.ts` のテーマ設定を `runtimeConfig.public` に格納
2. Nuxt plugin が `useRuntimeConfig()` から取得した値（`reactive()` でラップ済み）を `overrideTheme()` に渡す
3. `overrideTheme` 内の `structuredClone()` が Proxy オブジェクトを複製できず `DataCloneError`

## テスト計画

- [x] `pnpm type-check` パス
- [x] `pnpm test` 全767件パス
- [x] `pnpm lint:fix` パス
- [x] Nuxt 3 playground で structuredClone エラーが発生しないこと
- [x] テーマオーバーライド（info → pink）が正しく適用されること

Closes #856

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>