### PR TITLE
feat: トランジションdurationのCSS変数化とprefers-reduced-motion対応

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -373,11 +373,13 @@ font-feature-settings: 'palt';
 
 全コンポーネントで統一されたトランジション設定:
 
-- **Duration**: `0.2s`（全コンポーネント共通、ハードコード）
+- **Duration**: `var(--duration-fast)`（`--duration-fast: 0.2s` を全コンポーネント共通で参照）
 - **Easing**: `ease-in-out`（トランジションラッパーコンポーネントのデフォルト）
 - **アニメーション方式**: `@keyframes` は未使用。すべて CSS `transition` ベース
 
-> ⚠️ **既知の課題**: duration が CSS 変数化されておらず、`prefers-reduced-motion` にも未対応。将来的にトークン化と reduced-motion 対応を予定。
+`--duration-fast` は `--space-*` / `--radius-*` と同様のグローバルデザイントークンであり、通常はコンポーネント単位でのローカル上書きを想定しない。`prefers-reduced-motion: reduce` 環境では `--duration-fast: 0s` に切り替わり、全トランジション・`scroll-behavior`（`smooth` → `auto`）が即時化される。
+
+Dialog / Modal のクローズ処理は、この変数を文字列解析するのではなく `getComputedStyle()` で実際に適用された `transition-duration` / `transition-delay` を読み取って同期する（`src/assets/ts/transition.ts`）。そのため消費者側が `--duration-fast` を `calc()` などで上書きした場合でも、JS 側のクローズタイミングは実際の CSS トランジションと一致する。
 
 ### 5.2 グローバルトランジション
 
@@ -385,9 +387,9 @@ font-feature-settings: 'palt';
 
 | 対象 | プロパティ |
 |------|-----------|
-| `body` | `color 0.2s, background-color 0.2s` |
-| `img` | `opacity 0.2s` |
-| `a` | `color 0.2s` |
+| `body` | `color var(--duration-fast), background-color var(--duration-fast)` |
+| `img` | `opacity var(--duration-fast)` |
+| `a` | `color var(--duration-fast)` |
 
 ### 5.3 Hover / Touch 分離パターン
 
@@ -414,7 +416,7 @@ PC とモバイルでインタラクション方式を分離する:
 **OpacityTransition / OpacityTransitionGroup**
 
 - 純粋なフェードイン・フェードアウト
-- props: `duration`（デフォルト 0.2s）、`delay`、`easeFunction`
+- props: `duration`（デフォルト `var(--duration-fast)`）、`delay`、`easeFunction`
 
 **TranslateTransition / TranslateTransitionGroup**
 
@@ -556,7 +558,7 @@ brand カラーの上書き（`overrideTheme`）により任意の status 間で
 - Padding: `0 8px`
 - Border: `1px solid`
 - Border Radius: `4px`（default） / `2em`（rounded） / `0`（no-radius） / `50%`（circle）
-- Transition: `color 0.2s, background-color 0.2s, border-color 0.2s`
+- Transition: `color var(--duration-fast), background-color var(--duration-fast), border-color var(--duration-fast)`
 - Min Width: `100px`
 
 **API**
@@ -782,7 +784,7 @@ brand カラーの上書き（`overrideTheme`）により任意の status 間で
 - variant なし。アクティブタブは `--color-brand` でハイライト
 - `position`: `'top'`（デフォルト） / `'right' | 'bottom' | 'left'` でタブヘッダーの配置方向
 - `tabAlign`: `'start' | 'center' | 'end' | 'between'`
-- **アクティブボーダー**: `.active-border` 要素が `getBoundingClientRect()` に基づいて CSS `v-bind()` で動的に位置・サイズを計算。`width / height / top / right / bottom / left` が `0.2s` でアニメーション
+- **アクティブボーダー**: `.active-border` 要素が `getBoundingClientRect()` に基づいて CSS `v-bind()` で動的に位置・サイズを計算。`width / height / top / right / bottom / left` が `var(--duration-fast)` でアニメーション
 - タブヘッダーは `overflow: scroll` でオーバーフロー対応
 - `transition` prop: `'translate' | 'opacity'` でコンテンツ切替時のアニメーション方式を選択
 
@@ -909,7 +911,7 @@ Letter Spacing: 0.05em
 Spacing: --space-xs / --space-sm / --space-md / --space-lg / --space-xl / --space-2xl
 Border Radius: --radius-none / --radius-sm / --radius-pill / --radius-circle
 CSS Layer: @layer minazuki（消費者CSSが優先される）
-Transition: 0.2s（全コンポーネント統一）
+Transition: --duration-fast（全コンポーネント統一、reduced-motion で 0s）
 Icon Library: lucide-vue-next
 ```
 

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -17,7 +17,12 @@
         box-sizing: border-box;
         scrollbar-gutter: stable;
         font-size: 62.5%; /* 1rem = 10px */
-        scroll-behavior: smooth;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        :root {
+            scroll-behavior: auto;
+        }
     }
     body {
         min-height: var(--height-vh);
@@ -30,8 +35,8 @@
         word-break: break-all;
         text-size-adjust: 100%;
         transition:
-            color 0.2s,
-            background-color 0.2s;
+            color var(--duration-fast),
+            background-color var(--duration-fast);
         .container {
             min-height: var(--height-vh);
         }
@@ -50,11 +55,11 @@
     img {
         vertical-align: bottom;
         border: 0;
-        transition: opacity 0.2s;
+        transition: opacity var(--duration-fast);
     }
     a {
         color: var(--color-link);
-        transition: color 0.2s;
+        transition: color var(--duration-fast);
 
         @media (hover: hover) {
             /* PC */

--- a/src/assets/css/variables.css
+++ b/src/assets/css/variables.css
@@ -35,11 +35,20 @@
         --focus-ring-color: var(--color-brand-emphasis);
         --focus-ring-width: 2px;
         --focus-ring-offset: 2px;
+
+        /* Duration */
+        --duration-fast: 0.2s;
     }
 
     @media (600px <= width) {
         :root {
             --font-size-medium: 1.6rem;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        :root {
+            --duration-fast: 0s;
         }
     }
 }

--- a/src/assets/ts/transition.ts
+++ b/src/assets/ts/transition.ts
@@ -1,0 +1,30 @@
+const CSS_TIME_PATTERN = /^(-?\d+(?:\.\d+)?|-?\.\d+)(ms|s)$/i;
+
+const parseCssTime = (raw: string): number => {
+    const match = CSS_TIME_PATTERN.exec(raw.trim());
+    if (!match) return 0;
+    const value = parseFloat(match[1]);
+    if (!Number.isFinite(value)) return 0;
+    return match[2].toLowerCase() === 'ms' ? value : value * 1000;
+};
+
+const parseCssTimeList = (raw: string): number[] => raw.split(',').map(parseCssTime);
+
+/**
+ * 対象要素に実際に適用されているtransition-duration + transition-delayの最大値をミリ秒で返す。
+ * `--duration-fast`のテキスト解析ではなく計算済みスタイルから読むため、calc()や消費者側の
+ * カスタムプロパティ上書きがあっても実際のCSSトランジションと同期する。
+ * (SSR時・要素未取得時は200msにフォールバック。transition未設定時は0を返す)
+ */
+export const getTransitionDuration = (el: Element | null | undefined): number => {
+    if (typeof document === 'undefined' || !el) return 200;
+    const style = getComputedStyle(el);
+    const durations = parseCssTimeList(style.transitionDuration);
+    const delays = parseCssTimeList(style.transitionDelay);
+    const count = Math.max(durations.length, delays.length);
+    let max = 0;
+    for (let i = 0; i < count; i++) {
+        max = Math.max(max, (durations[i % durations.length] ?? 0) + (delays[i % delays.length] ?? 0));
+    }
+    return max;
+};

--- a/src/components/basic/Button.vue
+++ b/src/components/basic/Button.vue
@@ -122,9 +122,9 @@ defineExpose({ buttonRef });
     border-color: var(--c-button-border-color);
     border-radius: var(--radius-sm);
     transition:
-        color 0.2s,
-        background-color 0.2s,
-        border-color 0.2s;
+        color var(--duration-fast),
+        background-color var(--duration-fast),
+        border-color var(--duration-fast);
 
     @media (hover: hover) {
         &:hover:not(:disabled, .is-readonly) {

--- a/src/components/controls/Autocomplete.vue
+++ b/src/components/controls/Autocomplete.vue
@@ -360,7 +360,7 @@ defineExpose({ onBlur, debouncedSearchValue, value });
         width: var(--c-autocomplete-font-size);
         .lucide {
             opacity: 0;
-            transition: opacity 0.2s;
+            transition: opacity var(--duration-fast);
         }
     }
 }

--- a/src/components/controls/Checkbox.vue
+++ b/src/components/controls/Checkbox.vue
@@ -194,7 +194,7 @@ if (fieldVal.value == null && model.value != null) {
     line-height: 1em;
     color: var(--color-text-primary);
     pointer-events: none;
-    transition: 0.2s;
+    transition: var(--duration-fast);
     &.required {
         &::after {
             left: -0.5em;

--- a/src/components/controls/Field.vue
+++ b/src/components/controls/Field.vue
@@ -453,7 +453,7 @@ defineExpose({ onCloseDatePicker, isFocus, datePickerScrollObserver });
         }
         .lucide {
             opacity: 0;
-            transition: opacity 0.2s;
+            transition: opacity var(--duration-fast);
         }
     }
     .datepicker {

--- a/src/components/controls/Radio.vue
+++ b/src/components/controls/Radio.vue
@@ -193,7 +193,7 @@ if (fieldVal.value == null && model.value != null) {
     line-height: 1em;
     color: var(--color-text-primary);
     pointer-events: none;
-    transition: 0.2s;
+    transition: var(--duration-fast);
     &.required {
         &::after {
             left: -0.5em;

--- a/src/components/controls/Select.vue
+++ b/src/components/controls/Select.vue
@@ -186,7 +186,7 @@ const onDelete = () => {
         }
         .select-icon {
             font-size: var(--font-size-small);
-            transition: transform 0.2s;
+            transition: transform var(--duration-fast);
         }
         &.is-focus .select-icon {
             transform: rotateZ(180deg);
@@ -220,7 +220,7 @@ const onDelete = () => {
         width: var(--c-select-font-size);
         .lucide {
             opacity: 0;
-            transition: opacity 0.2s;
+            transition: opacity var(--duration-fast);
         }
     }
 }

--- a/src/components/controls/Switch.vue
+++ b/src/components/controls/Switch.vue
@@ -147,7 +147,7 @@ if (fieldVal.value == null && model.value != null) {
         height: var(--c-switch-font-size);
         background-color: var(--color-border);
         border-radius: var(--radius-pill);
-        transition: background-color 0.2s;
+        transition: background-color var(--duration-fast);
         .switch-icon {
             position: absolute;
             left: 0;
@@ -159,12 +159,12 @@ if (fieldVal.value == null && model.value != null) {
             background-color: var(--color-text-secondary);
             border-radius: var(--radius-circle);
             transform: scale(1.5);
-            transition: background-color 0.2s;
+            transition: background-color var(--duration-fast);
             .switch-icon-true,
             .switch-icon-false {
                 filter: invert(100%) grayscale(100%) contrast(100);
                 transform: scale(0.75);
-                transition: color 0.2s;
+                transition: color var(--duration-fast);
             }
             .switch-icon-true {
                 color: var(--c-switch-switch-icon-true-color);
@@ -220,7 +220,7 @@ if (fieldVal.value == null && model.value != null) {
     line-height: 1em;
     color: var(--color-text-primary);
     pointer-events: none;
-    transition: 0.2s;
+    transition: var(--duration-fast);
     &.required {
         &::after {
             left: -0.5em;
@@ -245,10 +245,10 @@ if (fieldVal.value == null && model.value != null) {
         min-height: var(--c-switch-height);
         line-height: 1.5em;
         transition:
-            color 0.2s,
-            background-color 0.2s,
-            border-color 0.2s,
-            opacity 0.2s;
+            color var(--duration-fast),
+            background-color var(--duration-fast),
+            border-color var(--duration-fast),
+            opacity var(--duration-fast);
     }
 }
 

--- a/src/components/controls/Textarea.vue
+++ b/src/components/controls/Textarea.vue
@@ -231,7 +231,7 @@ onMounted(() => {
         margin-bottom: auto;
         .lucide {
             opacity: 0;
-            transition: opacity 0.2s;
+            transition: opacity var(--duration-fast);
         }
     }
 }

--- a/src/components/feedback/Alert.vue
+++ b/src/components/feedback/Alert.vue
@@ -115,10 +115,10 @@ const onClosed = async () => {
     border-color: var(--c-alert-border-color);
     border-radius: var(--c-alert-border-radius);
     transition:
-        color 0.2s,
-        background-color 0.2s,
-        border-color 0.2s,
-        opacity 0.2s;
+        color var(--duration-fast),
+        background-color var(--duration-fast),
+        border-color var(--duration-fast),
+        opacity var(--duration-fast);
     .icon {
         flex-shrink: 0;
         width: calc(var(--font-size-medium) * 1.8);

--- a/src/components/feedback/Dialog.vue
+++ b/src/components/feedback/Dialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, useSlots, watch, onMounted, onBeforeUnmount, type Component } from 'vue';
 import TeleportRoot from '@/components/inner-parts/TeleportRoot.vue';
+import { getTransitionDuration } from '@/assets/ts/transition';
 import {
     Info as IconInfo,
     CheckCircle2 as IconCheckCircle2,
@@ -82,6 +83,7 @@ const transitionFromClass = computed(() => {
 });
 
 const dialogEl = ref<HTMLDialogElement | null>(null);
+const dialogPanelEl = ref<HTMLElement | null>(null);
 let closeTimeoutId: number | undefined;
 
 const finishClose = () => {
@@ -127,7 +129,9 @@ const open = () => {
 const startClose = () => {
     if (transitionState.value === 'is-closing') return;
     transitionState.value = 'is-closing';
-    closeTimeoutId = window.setTimeout(finishClose, 250);
+    const duration = getTransitionDuration(dialogPanelEl.value);
+    // 0ms(reduced-motion等)でもopen()からclearTimeoutでキャンセルできるよう、常に非同期でスケジュールする
+    closeTimeoutId = window.setTimeout(finishClose, duration === 0 ? 0 : duration + 50);
 };
 
 onMounted(() => {
@@ -184,7 +188,7 @@ const hasSlot = (name: string) => {
             @click="onBackdropClick"
             @cancel.prevent="onCancel"
         >
-            <div class="dialog-panel" :class="[position]" @click.stop>
+            <div ref="dialogPanelEl" class="dialog-panel" :class="[position]" @click.stop>
                 <component :is="frameComponent" class="dialog-frame">
                     <div
                         class="dialog"
@@ -230,7 +234,7 @@ const hasSlot = (name: string) => {
     &::backdrop {
         background-color: var(--color-shadow-alpha);
         opacity: 1;
-        transition: opacity 0.2s ease-in-out;
+        transition: opacity var(--duration-fast) ease-in-out;
     }
     &.is-opening::backdrop,
     &.is-closing::backdrop {
@@ -252,8 +256,8 @@ const hasSlot = (name: string) => {
     opacity: 1;
     transform: translate(0, 0);
     transition:
-        opacity 0.2s ease-in-out,
-        transform 0.2s ease-in-out;
+        opacity var(--duration-fast) ease-in-out,
+        transform var(--duration-fast) ease-in-out;
 }
 
 /* ▼ transition ▼ */
@@ -306,8 +310,8 @@ const hasSlot = (name: string) => {
     border-color: var(--c-dialog-border-color);
     border-radius: var(--c-dialog-border-radius);
     transition:
-        border-color 0.2s,
-        opacity 0.2s;
+        border-color var(--duration-fast),
+        opacity var(--duration-fast);
     .inner {
         display: flex;
         flex-grow: 1;

--- a/src/components/feedback/Drawer.vue
+++ b/src/components/feedback/Drawer.vue
@@ -203,8 +203,8 @@ defineExpose({ transitionFrom });
     border-color: var(--color-border);
     border-radius: var(--radius-none);
     transition:
-        border-color 0.2s,
-        opacity 0.2s;
+        border-color var(--duration-fast),
+        opacity var(--duration-fast);
     .closeable-box {
         position: absolute;
         top: 0;

--- a/src/components/feedback/Modal.vue
+++ b/src/components/feedback/Modal.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount, type Component } from 'vue';
 import TeleportRoot from '@/components/inner-parts/TeleportRoot.vue';
 import Button from '@/components/basic/Button.vue';
+import { getTransitionDuration } from '@/assets/ts/transition';
 import { X as IconX } from 'lucide-vue-next';
 
 const flg = defineModel<boolean>({ default: false });
@@ -68,6 +69,7 @@ const transitionFromClass = computed(() => {
 });
 
 const dialogEl = ref<HTMLDialogElement | null>(null);
+const modalPanelEl = ref<HTMLElement | null>(null);
 let closeTimeoutId: number | undefined;
 
 const finishClose = () => {
@@ -107,7 +109,9 @@ const open = () => {
 const startClose = () => {
     if (transitionState.value === 'is-closing') return;
     transitionState.value = 'is-closing';
-    closeTimeoutId = window.setTimeout(finishClose, 250);
+    const duration = getTransitionDuration(modalPanelEl.value);
+    // 0ms(reduced-motion等)でもopen()からclearTimeoutでキャンセルできるよう、常に非同期でスケジュールする
+    closeTimeoutId = window.setTimeout(finishClose, duration === 0 ? 0 : duration + 50);
 };
 
 const onClose = () => {
@@ -163,7 +167,7 @@ onBeforeUnmount(() => {
             @click="onBackdropClick"
             @cancel.prevent="onCancel"
         >
-            <div class="modal-panel" @click.stop>
+            <div ref="modalPanelEl" class="modal-panel" @click.stop>
                 <component :is="frameComponent" class="modal-frame">
                     <div
                         class="modal"
@@ -203,7 +207,7 @@ onBeforeUnmount(() => {
     &::backdrop {
         background-color: var(--color-shadow-alpha);
         opacity: 1;
-        transition: opacity 0.2s ease-in-out;
+        transition: opacity var(--duration-fast) ease-in-out;
     }
     &.is-opening::backdrop,
     &.is-closing::backdrop {
@@ -220,8 +224,8 @@ onBeforeUnmount(() => {
     opacity: 1;
     transform: translate(0, 0);
     transition:
-        opacity 0.2s ease-in-out,
-        transform 0.2s ease-in-out;
+        opacity var(--duration-fast) ease-in-out,
+        transform var(--duration-fast) ease-in-out;
 }
 
 /* ▼ transition ▼ */
@@ -275,8 +279,8 @@ onBeforeUnmount(() => {
     border-color: var(--color-border);
     border-radius: var(--c-modal-border-radius);
     transition:
-        border-color 0.2s,
-        opacity 0.2s;
+        border-color var(--duration-fast),
+        opacity var(--duration-fast);
     .closeable-box {
         position: absolute;
         top: 0;

--- a/src/components/feedback/NotificationItem.vue
+++ b/src/components/feedback/NotificationItem.vue
@@ -179,10 +179,10 @@ defineExpose({ flg, transitioning, isShowing, onClosed, transitionFrom });
     margin: auto;
     pointer-events: initial;
     transition:
-        top 0.2s,
-        bottom 0.2s,
-        border-color 0.2s,
-        opacity 0.2s;
+        top var(--duration-fast),
+        bottom var(--duration-fast),
+        border-color var(--duration-fast),
+        opacity var(--duration-fast);
     .notification-inner {
         display: flex;
         gap: var(--space-sm);

--- a/src/components/feedback/Progress.vue
+++ b/src/components/feedback/Progress.vue
@@ -183,7 +183,7 @@ const strokeDashoffset = computed(
             height: 100%;
             background-color: var(--c-progress-background-color);
             border-radius: var(--radius-pill);
-            transition: width 0.2s;
+            transition: width var(--duration-fast);
         }
     }
     .ratio {
@@ -214,7 +214,7 @@ const strokeDashoffset = computed(
         }
         .circle-overlay {
             color: var(--c-progress-background-color);
-            transition: stroke-dashoffset 0.2s;
+            transition: stroke-dashoffset var(--duration-fast);
         }
     }
 }

--- a/src/components/feedback/Rating.vue
+++ b/src/components/feedback/Rating.vue
@@ -129,8 +129,8 @@ watch(model, (v) => {
     font-size: var(--c-rating-font-size);
     color: var(--c-rating-color);
     transition:
-        color 0.2s,
-        background-color 0.2s;
+        color var(--duration-fast),
+        background-color var(--duration-fast);
     .rate {
         position: relative;
         display: flex;
@@ -141,8 +141,8 @@ watch(model, (v) => {
                 color: var(--c-rating-color);
                 fill: transparent;
                 transition:
-                    color 0.2s,
-                    fill 0.2s;
+                    color var(--duration-fast),
+                    fill var(--duration-fast);
             }
             &.is-over {
                 background-color: transparent;

--- a/src/components/inner-parts/FieldAccordionList.vue
+++ b/src/components/inner-parts/FieldAccordionList.vue
@@ -114,18 +114,18 @@ const onOutsideClick = computed(() => ({
     border-radius: var(--radius-sm);
     opacity: 0;
     transition:
-        background-color 0.2s,
-        opacity 0.2s,
-        grid-template-rows 0.2s ease,
-        opacity 0s 0.2s;
+        background-color var(--duration-fast),
+        opacity var(--duration-fast),
+        grid-template-rows var(--duration-fast) ease,
+        opacity 0s var(--duration-fast);
     &.is-open {
         grid-template-rows: 1fr;
         opacity: 1;
         transition:
-            color 0.2s,
-            background-color 0.2s,
-            opacity 0.2s,
-            grid-template-rows 0.2s ease;
+            color var(--duration-fast),
+            background-color var(--duration-fast),
+            opacity var(--duration-fast),
+            grid-template-rows var(--duration-fast) ease;
     }
     .list-body {
         overflow: hidden auto;
@@ -134,7 +134,7 @@ const onOutsideClick = computed(() => ({
             align-items: center;
             min-height: var(--c-field-accordion-height);
             padding: 0 var(--space-sm);
-            transition: background-color 0.2s;
+            transition: background-color var(--duration-fast);
 
             @media (hover: hover) {
                 &:hover {

--- a/src/components/inner-parts/FieldFrame.vue
+++ b/src/components/inner-parts/FieldFrame.vue
@@ -169,8 +169,8 @@ defineExpose({ frameRef });
         border-color: var(--c-field-frame-border-color);
         border-radius: var(--radius-sm);
         transition:
-            height 0.2s,
-            background-color 0.2s;
+            height var(--duration-fast),
+            background-color var(--duration-fast);
         .frame-start,
         .frame-end {
             position: relative;
@@ -216,7 +216,7 @@ defineExpose({ frameRef });
             border-width: var(--c-field-frame-border-width);
             border-right: 0;
             border-left: 0;
-            transition: border-width 0.2s;
+            transition: border-width var(--duration-fast);
             &::before {
                 position: absolute;
                 top: -2px;
@@ -240,14 +240,14 @@ defineExpose({ frameRef });
                 pointer-events: none;
                 transform: translateY(calc(-50% + (var(--c-field-frame-height) / 2) - 1px));
                 transition:
-                    transform 0.2s,
-                    font-size 0.2s;
+                    transform var(--duration-fast),
+                    font-size var(--duration-fast);
                 .label {
                     height: 1em;
                     line-height: 1em;
                     vertical-align: baseline;
                     color: var(--color-text-secondary);
-                    transition: color 0.2s;
+                    transition: color var(--duration-fast);
                 }
                 .placeholder {
                     height: 1em;

--- a/src/components/inner-parts/OpacityTransition.vue
+++ b/src/components/inner-parts/OpacityTransition.vue
@@ -15,7 +15,7 @@ withDefaults(
         easeFunction?: string;
     }>(),
     {
-        duration: '0.2s',
+        duration: 'var(--duration-fast)',
         delay: '0s',
         easeFunction: 'ease-in-out'
     }

--- a/src/components/inner-parts/OpacityTransitionGroup.vue
+++ b/src/components/inner-parts/OpacityTransitionGroup.vue
@@ -15,7 +15,7 @@ withDefaults(
         easeFunction?: string;
     }>(),
     {
-        duration: '0.2s',
+        duration: 'var(--duration-fast)',
         delay: '0s',
         easeFunction: 'ease-in-out'
     }

--- a/src/components/inner-parts/TranslateTransition.vue
+++ b/src/components/inner-parts/TranslateTransition.vue
@@ -28,7 +28,7 @@ withDefaults(
     }>(),
     {
         from: 'top',
-        duration: '0.2s',
+        duration: 'var(--duration-fast)',
         delay: '0s',
         easeFunction: 'ease-in-out'
     }

--- a/src/components/inner-parts/TranslateTransitionGroup.vue
+++ b/src/components/inner-parts/TranslateTransitionGroup.vue
@@ -28,7 +28,7 @@ withDefaults(
     }>(),
     {
         from: 'top',
-        duration: '0.2s',
+        duration: 'var(--duration-fast)',
         delay: '0s',
         easeFunction: 'ease-in-out'
     }

--- a/src/components/navigation/BottomNav.vue
+++ b/src/components/navigation/BottomNav.vue
@@ -121,15 +121,15 @@ const onClick = (item: MiBottomNavItem) => {
             width: calc(var(--c-bottom-nav-font-size) * 2);
             height: 100%;
             transition:
-                width 0.2s,
-                height 0.2s;
+                width var(--duration-fast),
+                height var(--duration-fast);
         }
         :deep(.button-label) {
             position: absolute;
             bottom: -1.5em;
             font-size: var(--font-size-small);
             line-height: 1;
-            transition: bottom 0.2s;
+            transition: bottom var(--duration-fast);
         }
         &.is-current {
             color: var(--color-text-primary);

--- a/src/components/navigation/Breadcrumb.vue
+++ b/src/components/navigation/Breadcrumb.vue
@@ -118,7 +118,7 @@ const onClick = (item: MiBreadcrumbItem) => {
         color: var(--color-link);
         text-decoration: none;
         cursor: pointer;
-        transition: color 0.2s;
+        transition: color var(--duration-fast);
 
         @media (hover: hover) {
             /* PC */

--- a/src/components/navigation/Pagination.vue
+++ b/src/components/navigation/Pagination.vue
@@ -242,7 +242,7 @@ const onClick = (page: number | undefined) => {
         justify-content: center;
         width: var(--c-pagination-size);
         height: var(--c-pagination-size);
-        transition: opacity 0.2s;
+        transition: opacity var(--duration-fast);
         .pagination-item-button {
             width: 100%;
             height: 100%;
@@ -258,8 +258,8 @@ const onClick = (page: number | undefined) => {
             visibility: hidden;
             opacity: 0;
             transition:
-                opacity 0.2s,
-                visibility 0s 0.2s;
+                opacity var(--duration-fast),
+                visibility 0s var(--duration-fast);
         }
     }
 }

--- a/src/components/navigation/Step.vue
+++ b/src/components/navigation/Step.vue
@@ -172,8 +172,8 @@ const hasSlot = (name: string) => {
             background: transparent;
             border: 0;
             transition:
-                opacity 0.2s,
-                color 0.2s;
+                opacity var(--duration-fast),
+                color var(--duration-fast);
             &:disabled,
             &.is-readonly {
                 cursor: not-allowed;
@@ -189,14 +189,14 @@ const hasSlot = (name: string) => {
                 color: var(--color-bg-secondary);
                 background-color: var(--color-text-secondary);
                 border-radius: var(--radius-circle);
-                transition: background-color 0.2s;
+                transition: background-color var(--duration-fast);
             }
             .text {
                 width: 100px;
                 text-align: center;
                 word-break: break-all;
                 transform: scale(0.8);
-                transition: transform 0.2s;
+                transition: transform var(--duration-fast);
             }
             &.is-current {
                 /* Buttonコンポーネント自身がこの変数でcolorを確定するため、継承ではなく直接上書きする */
@@ -227,7 +227,7 @@ const hasSlot = (name: string) => {
                 content: '';
                 background-color: var(--color-success);
                 transform: scale(0);
-                transition: transform 0.2s;
+                transition: transform var(--duration-fast);
             }
         }
     }

--- a/src/components/navigation/Tab.vue
+++ b/src/components/navigation/Tab.vue
@@ -165,12 +165,12 @@ defineExpose({ tabAlignProperty, tabButtonRef, currentTabClientRects });
             pointer-events: none;
             background-color: var(--color-brand);
             transition:
-                width 0.2s,
-                height 0.2s,
-                top 0.2s,
-                right 0.2s,
-                bottom 0.2s,
-                left 0.2s;
+                width var(--duration-fast),
+                height var(--duration-fast),
+                top var(--duration-fast),
+                right var(--duration-fast),
+                bottom var(--duration-fast),
+                left var(--duration-fast);
         }
     }
     .tab-slot {

--- a/src/generate-css-data.ts
+++ b/src/generate-css-data.ts
@@ -115,6 +115,8 @@ const RADIUS_TOKENS = [
     { name: 'circle', value: '50%', desc: 'Circular display' }
 ];
 
+const DURATION_TOKENS = [{ name: 'fast', value: '0.2s', desc: 'Standard transition duration' }];
+
 for (const token of SPACING_TOKENS) {
     properties.push({
         name: `--space-${token.name}`,
@@ -125,6 +127,13 @@ for (const token of SPACING_TOKENS) {
 for (const token of RADIUS_TOKENS) {
     properties.push({
         name: `--radius-${token.name}`,
+        description: `${token.desc} (${token.value})`
+    });
+}
+
+for (const token of DURATION_TOKENS) {
+    properties.push({
+        name: `--duration-${token.name}`,
         description: `${token.desc} (${token.value})`
     });
 }


### PR DESCRIPTION
## Summary

closes #843

- ハードコードされた `0.2s` を CSS 変数 `--duration-fast` に統一（27ファイル・約85箇所）
- `prefers-reduced-motion: reduce` で `--duration-fast: 0s` + `scroll-behavior: auto` に自動切替
- Dialog/Modal の `setTimeout` を CSS 変数連動に改修し、reduced-motion 時は即時クローズ
- `style.css` の重複 `scroll-behavior: smooth` 宣言を修正
- `generate-css-data.ts` に duration トークン追加（IDE 補完対応）
- `docs/DESIGN.md` にトークン仕様を追記

## 変更ファイル

- 30ファイル修正 + 1ファイル新規（`src/assets/ts/transition.ts`）

## Test plan

- [x] `pnpm lint:fix` パス
- [x] `pnpm type-check` パス
- [x] `pnpm build` パス
- [x] Vue3 playground: CSS変数値・Dialog/Modal開閉・全ページコンソールエラーなし
- [x] Nuxt3 playground: CSS変数値・Dialog/Modal開閉・Hydrationエラーなし・全ページコンソールエラーなし
- [x] Nuxt4 playground: CSS変数値・Dialog/Modal開閉・Hydrationエラーなし・全ページコンソールエラーなし
- [x] `prefers-reduced-motion: reduce` 時に `--duration-fast: 0s`, `scroll-behavior: auto` に切り替わること（3環境で確認）
- [x] reduced-motion 時に Dialog/Modal が即時クローズされること（3環境で確認）

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>