### PR TITLE
fix: MiModal/MiDialogのスクロール・トランジション・focus-visible不具合を修正

### DIFF
--- a/src/components/feedback/Dialog.vue
+++ b/src/components/feedback/Dialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, useSlots, watch, onMounted, onBeforeUnmount, type Component } from 'vue';
+import { ref, computed, useSlots, watch, nextTick, onMounted, onBeforeUnmount, type Component } from 'vue';
 import TeleportRoot from '@/components/inner-parts/TeleportRoot.vue';
 import { getTransitionDuration } from '@/assets/ts/transition';
 import {
@@ -94,13 +94,14 @@ const finishClose = () => {
     emit('closed');
 };
 
-const open = () => {
+const open = async () => {
     if (closeTimeoutId !== undefined) {
         window.clearTimeout(closeTimeoutId);
         closeTimeoutId = undefined;
     }
 
     transitionState.value = 'is-opening';
+    await nextTick();
 
     if (!dialogEl.value?.open) {
         if (props.seamless) {
@@ -114,12 +115,13 @@ const open = () => {
         document.documentElement.style.overflow = 'hidden';
     }
 
+    // showModal() 後に reflow を強制し、is-opening の初期スタイルをブラウザに確定させる
+    dialogPanelEl.value?.getBoundingClientRect();
+
     requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-            if (transitionState.value === 'is-opening') {
-                transitionState.value = '';
-            }
-        });
+        if (transitionState.value === 'is-opening') {
+            transitionState.value = '';
+        }
     });
 };
 
@@ -311,7 +313,7 @@ const hasSlot = (name: string) => {
     .inner {
         display: flex;
         flex-grow: 1;
-        align-items: flex-start;
+        min-height: 0;
         overflow: hidden;
     }
     .icon {
@@ -325,18 +327,20 @@ const hasSlot = (name: string) => {
     }
     .box {
         display: flex;
+        flex-grow: 1;
         flex-direction: column;
         gap: var(--space-sm);
         width: 100%;
-        height: 100%;
+        min-height: 0;
         .title {
+            flex-shrink: 0;
             padding: 0 var(--space-sm);
             font-size: calc(var(--font-size-medium) * 1.2);
             font-weight: bold;
         }
         .slot {
             flex-grow: 1;
-            height: 100%;
+            min-height: 0;
             padding: 0 var(--space-sm);
             overflow-y: auto;
         }

--- a/src/components/feedback/Dialog.vue
+++ b/src/components/feedback/Dialog.vue
@@ -199,7 +199,7 @@ const hasSlot = (name: string) => {
                             <IconXOctagon v-else-if="variant === 'danger'" class="icon" />
                             <div class="box">
                                 <div v-if="title" class="title">{{ title }}</div>
-                                <div class="slot">
+                                <div class="slot" tabindex="-1">
                                     <slot />
                                 </div>
                             </div>
@@ -343,6 +343,9 @@ const hasSlot = (name: string) => {
             min-height: 0;
             padding: 0 var(--space-sm);
             overflow-y: auto;
+            &:focus {
+                outline: none;
+            }
         }
     }
     .footer {

--- a/src/components/feedback/Drawer.vue
+++ b/src/components/feedback/Drawer.vue
@@ -218,6 +218,7 @@ defineExpose({ transitionFrom });
     }
     .header {
         display: flex;
+        flex-shrink: 0;
         gap: var(--space-sm);
         justify-content: flex-end;
         &.is-closeable {
@@ -227,12 +228,14 @@ defineExpose({ transitionFrom });
     .box {
         position: relative;
         flex-grow: 1;
+        min-height: 0;
         &.is-scroll {
             overflow-y: auto;
         }
     }
     .footer {
         display: flex;
+        flex-shrink: 0;
         gap: var(--space-sm);
         justify-content: flex-end;
     }

--- a/src/components/feedback/Modal.vue
+++ b/src/components/feedback/Modal.vue
@@ -292,15 +292,16 @@ onBeforeUnmount(() => {
         display: flex;
         flex-grow: 1;
         gap: var(--space-sm);
-        align-items: flex-start;
+        min-height: 0;
         overflow: hidden;
     }
     .box {
         display: flex;
+        flex-grow: 1;
         flex-direction: column;
         gap: var(--space-sm);
         width: 100%;
-        height: 100%;
+        min-height: 0;
         .title {
             padding: 0 var(--space-sm);
             font-size: calc(var(--font-size-medium) * 1.2);
@@ -308,7 +309,7 @@ onBeforeUnmount(() => {
         }
         .slot {
             flex-grow: 1;
-            height: 100%;
+            min-height: 0;
             padding: 0 var(--space-sm);
             overflow-y: auto;
         }

--- a/src/components/feedback/Modal.vue
+++ b/src/components/feedback/Modal.vue
@@ -170,6 +170,7 @@ onBeforeUnmount(() => {
                     <div
                         class="modal"
                         :class="[size, shape, { 'is-center': center, 'is-full-size-by-sp': isFullSizeBySp }]"
+                        tabindex="-1"
                     >
                         <Button size="large" shape="skeleton" class="closeable-box" :prefix-icon="IconX" aria-label="閉じる" @click="onClose" />
                         <div class="inner">
@@ -261,6 +262,10 @@ onBeforeUnmount(() => {
 
 .modal {
     position: relative;
+    &:focus {
+        outline: none;
+    }
+
     display: flex;
     flex-direction: column;
     gap: var(--space-sm);

--- a/src/components/feedback/Modal.vue
+++ b/src/components/feedback/Modal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onBeforeUnmount, type Component } from 'vue';
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount, type Component } from 'vue';
 import TeleportRoot from '@/components/inner-parts/TeleportRoot.vue';
 import Button from '@/components/basic/Button.vue';
 import { getTransitionDuration } from '@/assets/ts/transition';
@@ -80,13 +80,14 @@ const finishClose = () => {
     emit('closed');
 };
 
-const open = () => {
+const open = async () => {
     if (closeTimeoutId !== undefined) {
         window.clearTimeout(closeTimeoutId);
         closeTimeoutId = undefined;
     }
 
     transitionState.value = 'is-opening';
+    await nextTick();
 
     if (!dialogEl.value?.open) {
         dialogEl.value?.showModal();
@@ -94,12 +95,13 @@ const open = () => {
 
     document.documentElement.style.overflow = 'hidden';
 
+    // showModal() 後に reflow を強制し、is-opening の初期スタイルをブラウザに確定させる
+    modalPanelEl.value?.getBoundingClientRect();
+
     requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-            if (transitionState.value === 'is-opening') {
-                transitionState.value = '';
-            }
-        });
+        if (transitionState.value === 'is-opening') {
+            transitionState.value = '';
+        }
     });
 };
 

--- a/src/components/feedback/Modal.vue
+++ b/src/components/feedback/Modal.vue
@@ -303,6 +303,7 @@ onBeforeUnmount(() => {
         width: 100%;
         min-height: 0;
         .title {
+            flex-shrink: 0;
             padding: 0 var(--space-sm);
             font-size: calc(var(--font-size-medium) * 1.2);
             font-weight: bold;

--- a/src/components/navigation/Step.vue
+++ b/src/components/navigation/Step.vue
@@ -234,14 +234,16 @@ const hasSlot = (name: string) => {
     .step-content {
         display: flex;
         flex-direction: column;
+        min-height: 0;
     }
     .step-slot {
         flex-grow: 1;
-        height: 100%;
+        min-height: 0;
         overflow-y: auto;
     }
     .step-footer {
         display: flex;
+        flex-shrink: 0;
         justify-content: space-between;
         margin-top: var(--space-sm);
         &:not(.no-separator) {

--- a/src/components/navigation/Tab.vue
+++ b/src/components/navigation/Tab.vue
@@ -175,7 +175,7 @@ defineExpose({ tabAlignProperty, tabButtonRef, currentTabClientRects });
     }
     .tab-slot {
         flex-grow: 1;
-        height: 100%;
+        min-height: 0;
         overflow-y: auto;
     }
 }

--- a/src/stories/feedback/Modal.stories.ts
+++ b/src/stories/feedback/Modal.stories.ts
@@ -186,6 +186,28 @@ export const PropsPersistent: Story = {
     }
 };
 
+export const ScrollContent: Story = {
+    render: (args: Args) => ({
+        components: { Modal, Button },
+        setup: () => ({
+            args,
+            params: ref([
+                { size: 'small', modelValue: false },
+                { size: 'medium', modelValue: false }
+            ])
+        }),
+        template: `
+<template v-for="param in params" :key="param.size">
+    <Button :label="'Scroll Test (' + param.size + ')'" @click="param.modelValue = true" />
+    <Modal v-bind="{...args, ...param}" v-model="param.modelValue" title="Scroll Test">
+        <ul>
+            <li v-for="i in 30" :key="i">Item {{ i }} - リスト項目</li>
+        </ul>
+    </Modal>
+</template>`
+    })
+};
+
 export const PropsFrameComponent: Story = {
     render: (args: Args) => ({
         components: { Modal, Button },

--- a/src/test/components/feedback/Dialog.spec.ts
+++ b/src/test/components/feedback/Dialog.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { nextTick } from 'vue';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import Dialog from '@/components/feedback/Dialog.vue';
 
 describe('Dialog', () => {
@@ -9,10 +9,11 @@ describe('Dialog', () => {
         document.documentElement.style.overflow = '';
     });
 
-    it('v-model が true のとき dialog が open になる', () => {
-        const wrapper = mount(Dialog, { props: { modelValue: true } });
-        const dialog = wrapper.find('.component-dialog').element as HTMLDialogElement;
-        expect(dialog.open).toBe(true);
+    it('v-model が true のとき dialog が open になる', async () => {
+        mount(Dialog, { props: { modelValue: true }, attachTo: document.body });
+        await flushPromises();
+        const dialog = document.querySelector('.component-dialog') as HTMLDialogElement;
+        expect(dialog?.open).toBe(true);
     });
 
     it('v-model が false のとき dialog が open にならない', () => {
@@ -80,19 +81,21 @@ describe('Dialog', () => {
         expect(wrapper.find('.component-dialog').classes()).toContain('is-seamless');
     });
 
-    it('seamless のとき show() が使われる', () => {
+    it('seamless のとき show() が使われる', async () => {
         const showSpy = vi.spyOn(HTMLDialogElement.prototype, 'show');
         const showModalSpy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
         mount(Dialog, { props: { modelValue: true, seamless: true } });
+        await nextTick();
         expect(showSpy).toHaveBeenCalled();
         expect(showModalSpy).not.toHaveBeenCalled();
         showSpy.mockRestore();
         showModalSpy.mockRestore();
     });
 
-    it('seamless でないとき showModal() が使われる', () => {
+    it('seamless でないとき showModal() が使われる', async () => {
         const showModalSpy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
         mount(Dialog, { props: { modelValue: true } });
+        await nextTick();
         expect(showModalSpy).toHaveBeenCalled();
         showModalSpy.mockRestore();
     });
@@ -196,11 +199,13 @@ describe('Dialog', () => {
     it('v-model が false → true に変わると overflow が hidden になる', async () => {
         const wrapper = mount(Dialog, { props: { modelValue: false } });
         await wrapper.setProps({ modelValue: true });
+        await nextTick();
         expect(document.documentElement.style.overflow).toBe('hidden');
     });
 
-    it('seamless のとき overflow が hidden にならない', () => {
+    it('seamless のとき overflow が hidden にならない', async () => {
         mount(Dialog, { props: { modelValue: true, seamless: true } });
+        await nextTick();
         expect(document.documentElement.style.overflow).not.toBe('hidden');
     });
 
@@ -212,6 +217,7 @@ describe('Dialog', () => {
                 'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
             }
         });
+        await nextTick();
         expect(document.documentElement.style.overflow).toBe('hidden');
         await wrapper.setProps({ modelValue: false });
         await vi.advanceTimersByTimeAsync(300);
@@ -219,8 +225,9 @@ describe('Dialog', () => {
         expect(document.documentElement.style.overflow).toBe('');
     });
 
-    it('unmount 時に overflow がリセットされる', () => {
+    it('unmount 時に overflow がリセットされる', async () => {
         const wrapper = mount(Dialog, { props: { modelValue: true } });
+        await nextTick();
         expect(document.documentElement.style.overflow).toBe('hidden');
         wrapper.unmount();
         expect(document.documentElement.style.overflow).toBe('');

--- a/src/test/components/feedback/Modal.spec.ts
+++ b/src/test/components/feedback/Modal.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { nextTick } from 'vue';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import Modal from '@/components/feedback/Modal.vue';
 
 describe('Modal', () => {
@@ -9,10 +9,11 @@ describe('Modal', () => {
         document.documentElement.style.overflow = '';
     });
 
-    it('v-model が true のとき modal が open になる', () => {
-        const wrapper = mount(Modal, { props: { modelValue: true } });
-        const dialog = wrapper.find('.component-modal').element as HTMLDialogElement;
-        expect(dialog.open).toBe(true);
+    it('v-model が true のとき modal が open になる', async () => {
+        mount(Modal, { props: { modelValue: true }, attachTo: document.body });
+        await flushPromises();
+        const dialog = document.querySelector('.component-modal') as HTMLDialogElement;
+        expect(dialog?.open).toBe(true);
     });
 
     it('v-model が false のとき modal が open にならない', () => {
@@ -161,6 +162,7 @@ describe('Modal', () => {
     it('v-model が false → true に変わると overflow が hidden になる', async () => {
         const wrapper = mount(Modal, { props: { modelValue: false } });
         await wrapper.setProps({ modelValue: true });
+        await nextTick();
         expect(document.documentElement.style.overflow).toBe('hidden');
     });
 
@@ -172,6 +174,7 @@ describe('Modal', () => {
                 'onUpdate:modelValue': (v: boolean) => wrapper.setProps({ modelValue: v })
             }
         });
+        await nextTick();
         expect(document.documentElement.style.overflow).toBe('hidden');
         await wrapper.setProps({ modelValue: false });
         await vi.advanceTimersByTimeAsync(300);
@@ -179,8 +182,9 @@ describe('Modal', () => {
         expect(document.documentElement.style.overflow).toBe('');
     });
 
-    it('unmount 時に overflow がリセットされる', () => {
+    it('unmount 時に overflow がリセットされる', async () => {
         const wrapper = mount(Modal, { props: { modelValue: true } });
+        await nextTick();
         expect(document.documentElement.style.overflow).toBe('hidden');
         wrapper.unmount();
         expect(document.documentElement.style.overflow).toBe('');
@@ -197,9 +201,10 @@ describe('Modal', () => {
         expect(wrapper.props('modelValue')).toBe(true);
     });
 
-    it('showModal() が使用される', () => {
+    it('showModal() が使用される', async () => {
         const showModalSpy = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
         mount(Modal, { props: { modelValue: true } });
+        await nextTick();
         expect(showModalSpy).toHaveBeenCalled();
         showModalSpy.mockRestore();
     });


### PR DESCRIPTION
## Summary

- MiModal のコンテンツがモーダル高を超えた場合にスクロールできない問題を修正（#860）
- MiModal のタイトルがスクロールコンテンツに潰される問題を修正
- MiModal/MiDialog の表示時トランジションが発火しない問題を修正
- `showModal()` の自動フォーカスにより Cancel/Close ボタンに `:focus-visible` が適用され、border と outline が重なって二重枠に見える問題を修正
- 上記バグパターンを Dialog・Drawer・Tab・Step に水平展開

### 修正パターン

| パターン | 原因 | 修正 |
|---|---|---|
| スクロール不可 | flex の `min-height: auto` と `align-items: flex-start` により高さ制約が伝播しない | `min-height: 0` + `align-items` 削除 + `flex-grow: 1` |
| タイトル潰れ | flex コンテナ内で縮小される | `flex-shrink: 0` |
| トランジション不発火 | Vue の非同期 DOM 更新により `showModal()` 時に CSS クラスが未適用 | `await nextTick()` + `getBoundingClientRect()` による reflow 強制 |
| focus-visible 二重枠 | `showModal()` の自動フォーカスが最初のボタンに当たり Chrome が `:focus-visible` を適用 | コンテンツラッパーに `tabindex="-1"` を追加してフォーカス先を変更 |

## Test plan

- [x] lint・型チェック pass
- [x] テスト pass（async open() に合わせてテスト更新済み）
- [x] Storybook で Modal/Dialog のスクロール・トランジション・focus-visible を確認
- [x] playground 3環境（Vue / Nuxt3 / Nuxt4）での動作確認

Generated with [Claude Code](https://claude.ai/code)

closes #860