### PR TITLE
fix: DialogのStoryPlayerでアイコンが未定義になるエラーを修正

### DIFF
--- a/src/stories/feedback/Dialog.stories.ts
+++ b/src/stories/feedback/Dialog.stories.ts
@@ -286,8 +286,8 @@ export const PropsFrameComponent: Story = {
 
 export const StoryPlayer: Story = {
     render: (args: Args) => ({
-        components: { Dialog, Button, Progress, IconPlay, IconPause, IconX },
-        setup: () => ({ args, progressModel: 75 }),
+        components: { Dialog, Button, Progress },
+        setup: () => ({ args, progressModel: 75, IconPlay, IconPause, IconX }),
         template: `
 <Button label="Open Player" @click="args.modelValue = true" />
 <Dialog v-bind="args">


### PR DESCRIPTION
## Summary
- DialogのStoryPlayerストーリーで`IconPlay`, `IconPause`, `IconX`が`components`に登録されていたが、`setup()`の戻り値に含まれていなかったため、テンプレート内の`:prefix-icon="IconPlay"`等で未定義エラーが発生していた
- `components`からアイコンを除去し、`setup()`の戻り値に移動して修正

## Test plan
- [x] Storybookを起動し、Dialog > StoryPlayerストーリーでアイコン関連のエラーが出ないことを確認
- [x] StoryPlayerの再生・一時停止・閉じるボタンにアイコンが正しく表示されることを確認

Generated with [Claude Code](https://claude.ai/code)