### PR TITLE
fix(a11y): input要素にlabel[for]/id属性による明示的ラベル関連付けを追加

### DIFF
--- a/src/components/controls/Autocomplete.vue
+++ b/src/components/controls/Autocomplete.vue
@@ -273,10 +273,12 @@ defineExpose({ onBlur, debouncedSearchValue, value });
             :value="value"
             :isErrorMessage="isErrorMessage"
             :errors="errors"
+            :input-id="generatedId"
         >
             <slot name="prefix" />
             <div v-if="prefix" class="prefix-suffix">{{ prefix }}</div>
             <input
+                :id="generatedId"
                 v-model.trim="value"
                 class="input"
                 :type="type"

--- a/src/components/controls/Field.vue
+++ b/src/components/controls/Field.vue
@@ -316,14 +316,16 @@ defineExpose({ onCloseDatePicker, isFocus, datePickerScrollObserver });
             :value="value"
             :isErrorMessage="isErrorMessage"
             :errors="errors"
+            :input-id="generatedId"
         >
             <slot name="prefix" />
             <div v-if="prefix" class="prefix-suffix">{{ prefix }}</div>
-            <button v-if="type === 'date'" class="input" @click="onDateButonClick">
+            <button v-if="type === 'date'" :id="generatedId" class="input" @click="onDateButonClick">
                 <span>{{ value ? dayjs(value).format(format) : '' }}</span>
             </button>
             <input
                 v-else
+                :id="generatedId"
                 v-model.trim="formatValue"
                 class="input"
                 :type="fieldType"

--- a/src/components/controls/Textarea.vue
+++ b/src/components/controls/Textarea.vue
@@ -154,8 +154,10 @@ onMounted(() => {
             :value="value"
             :isErrorMessage="isErrorMessage"
             :errors="errors"
+            :input-id="generatedId"
         >
             <textarea
+                :id="generatedId"
                 ref="textareaRef"
                 v-model="value"
                 class="textarea"

--- a/src/components/inner-parts/FieldFrame.vue
+++ b/src/components/inner-parts/FieldFrame.vue
@@ -59,6 +59,10 @@ withDefaults(
          * タグ
          */
         bodyTag?: string;
+        /**
+         * 入力要素のID（label[for]による明示的関連付け用）
+         */
+        inputId?: string;
     }>(),
     {
         label: '',
@@ -110,7 +114,12 @@ defineExpose({ frameRef });
                 <div class="frame-start" />
                 <div class="frame-label">
                     <div class="label-box">
-                        <span v-if="label || required" class="label">{{ label }}</span
+                        <component
+                            :is="inputId ? 'label' : 'span'"
+                            v-if="label || required"
+                            class="label"
+                            :for="inputId || undefined"
+                        >{{ label }}</component
                         ><span v-if="placeholder" class="placeholder"
                             >（例：{{ placeholder }}）</span
                         >
@@ -247,6 +256,8 @@ defineExpose({ frameRef });
                     line-height: 1em;
                     vertical-align: baseline;
                     color: var(--color-text-secondary);
+                    pointer-events: auto;
+                    cursor: text;
                     transition: color var(--duration-fast);
                 }
                 .placeholder {
@@ -302,6 +313,10 @@ defineExpose({ frameRef });
     &.is-disabled {
         pointer-events: none;
         opacity: 0.5;
+        .label-box .label {
+            pointer-events: none;
+            cursor: default;
+        }
     }
 
     /* focus */


### PR DESCRIPTION
## 概要

Closes #869

FieldFrame を使用するフォームコンポーネント（Field, Textarea, Autocomplete）で、`<input>` / `<textarea>` 要素に明示的な `label[for]`/`id` によるラベル関連付けを追加し、Lighthouse Accessibility の「Form elements do not have associated labels」違反を解消します。

## 変更内容

- **FieldFrame.vue**: `inputId` prop を追加。指定時はラベルテキスト要素を `<label for="inputId">` で描画し、`pointer-events: auto` でクリックによるフォーカス移動を有効化。disabled 時は CSS specificity を合わせて `pointer-events: none` / `cursor: default` で上書き
- **Field.vue / Textarea.vue / Autocomplete.vue**: FieldFrame に `:input-id="generatedId"` を渡し、各入力要素に `:id="generatedId"` を設定

## 設計判断

- `bodyTag` のデフォルトは `'label'` のまま維持（パディング領域の click-to-focus UX を保持）
- Select.vue / DatePicker.vue は `inputId` を渡さない（ネイティブフォーム要素がないため `label[for]` が不要）
- `generatedId`（`useId()` 由来）を HTML `id` に流用（vee-validate の `fieldName` とは別コンテキストで競合なし）

## テスト計画

- [ ] Playground（Vue）の Forms ページで、ラベルクリック → input にフォーカスが移動することを確認
- [ ] パディング領域のクリックでも input にフォーカスすることを確認（bodyTag='label' による UX 維持）
- [ ] disabled フィールドでラベルの cursor が `text` でないことを確認
- [ ] MiSelect の開閉動作に影響がないことを確認
- [ ] Lighthouse Accessibility で「Form elements do not have associated labels」が解消されることを確認

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>