### PR TITLE
feat!: MiDatePickerをサブエントリポイントに分離 (#870)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
     },
+    "./datepicker": {
+      "types": "./dist/datepicker.d.ts",
+      "import": "./dist/datepicker.js"
+    },
     "./nuxt": {
       "types": "./dist/nuxt/module.d.ts",
       "import": "./dist/nuxt/module.mjs"
@@ -50,7 +54,7 @@
     "build": "pnpm create-component-d && run-p type-check \"build-only {@}\" -- && pnpm build:nuxt && pnpm generate-css-data",
     "build:nuxt": "vite build --config vite.nuxt.config.ts",
     "preview": "vite preview",
-    "build-only": "vite build",
+    "build-only": "vite build && vite build --config vite.datepicker.config.ts",
     "type-check": "vue-tsc --build --force",
     "create-component-d": "node ./src/generate-component-index.js",
     "generate-css-data": "jiti ./src/generate-css-data.ts",
@@ -92,6 +96,15 @@
   },
   "peerDependenciesMeta": {
     "@nuxt/kit": {
+      "optional": true
+    },
+    "@vuepic/vue-datepicker": {
+      "optional": true
+    },
+    "@vee-validate/rules": {
+      "optional": true
+    },
+    "@vee-validate/zod": {
       "optional": true
     }
   },

--- a/playground/nuxt3/nuxt.config.ts
+++ b/playground/nuxt3/nuxt.config.ts
@@ -24,6 +24,7 @@ export default defineNuxtConfig({
     // (playground/shared/pages/HomePage.vue の Theme Override セクション参照)
     minazukiUi: {
         themeId: 'light',
+        datepicker: true,
         theme: {
             statuses: {
                 info: { hue: 'pink', chroma: 'pink' }

--- a/playground/nuxt4/nuxt.config.ts
+++ b/playground/nuxt4/nuxt.config.ts
@@ -22,7 +22,8 @@ export default defineNuxtConfig({
     devtools: { enabled: false },
     modules: ['@pinia/nuxt', ...(existsSync(minazukiNuxtModule) ? [minazukiNuxtModule] : [])],
     minazukiUi: {
-        themeId: 'light'
+        themeId: 'light',
+        datepicker: true
     },
     css: ['playground-shared/styles/playground.css'],
     build: {

--- a/playground/vue/src/main.ts
+++ b/playground/vue/src/main.ts
@@ -1,6 +1,5 @@
 import '@acab/reset.css';
 import 'minazuki-ui/dist/style.css';
-import '@vuepic/vue-datepicker/dist/main.css';
 
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
@@ -8,6 +7,7 @@ import { createHead } from '@unhead/vue';
 import { createRouter, createWebHistory } from 'vue-router';
 import { setupValidate } from 'playground-shared/validate';
 import MinazukiUi from 'minazuki-ui';
+import MinazukiUiDatepicker from 'minazuki-ui/datepicker';
 
 import App from './App.vue';
 import HomePage from 'playground-shared/pages/HomePage.vue';
@@ -40,5 +40,6 @@ app.use(MinazukiUi, {
         }
     }
 });
+app.use(MinazukiUiDatepicker);
 
 app.mount('#app');

--- a/src/components/controls/Field.vue
+++ b/src/components/controls/Field.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { computed, useId, watch, ref, onMounted, onBeforeUnmount } from 'vue';
+import { computed, defineAsyncComponent, useId, watch, ref, onMounted, onBeforeUnmount } from 'vue';
 import { useField } from 'vee-validate';
 import type { ZodTypeAny } from 'zod';
 import { resolveStringChecks } from '@/assets/ts/schema';
 import FieldFrame from '@/components/inner-parts/FieldFrame.vue';
-import DatePicker from '@/components/controls/DatePicker.vue';
+import type DatePickerType from '@/components/controls/DatePicker.vue';
 import OpacityTransition from '@/components/inner-parts/OpacityTransition.vue';
 import {
     XCircle as IconXCircle,
@@ -17,6 +17,10 @@ import {
 import { DATE_FORMAT } from '@/assets/ts/const';
 import dayjs from 'dayjs';
 import useOutsideClick from '@/directives/useOutsideClick';
+
+const DatePicker = defineAsyncComponent(
+    () => import('@/components/controls/DatePicker.vue')
+);
 
 export type MiDateFormat = (typeof DATE_FORMAT)[keyof typeof DATE_FORMAT];
 export type MiFieldType =
@@ -211,14 +215,14 @@ const onHidePassword = () => {
 
 // --- ▼ type: Date時の処理 ▼ ---
 const onDateButonClick = () => {
-    if (datePickerScrollObserver.value) {
-        datePickerScrollObserver.value!.observe(datepickerRef.value!.elementRef!);
+    if (datePickerScrollObserver.value && datepickerRef.value?.elementRef) {
+        datePickerScrollObserver.value.observe(datepickerRef.value.elementRef);
     }
     isFocus.value = true;
 };
 
 // DatePicker枠外制御/表示位置制御
-const datepickerRef = ref<InstanceType<typeof DatePicker> | null>(null);
+const datepickerRef = ref<InstanceType<typeof DatePickerType> | null>(null);
 const datePickerScrollObserver = ref<IntersectionObserver>();
 const onCloseDatePicker = () => {
     if (!isFocus.value || props.type !== 'date') return;
@@ -236,6 +240,8 @@ const onDatePickerUpdate = () => {
 };
 onMounted(() => {
     const intersect = (entries: IntersectionObserverEntry[]) => {
+        const el = datepickerRef.value?.elementRef;
+        if (!el) return;
         entries.forEach((entry) => {
             if (!entry.isIntersecting) {
                 const elementCenterY =
@@ -247,18 +253,18 @@ onMounted(() => {
                 const isLeft = window.innerWidth / 2 > elementCenterX;
                 const isRight = window.innerWidth / 2 < elementCenterX;
                 if (isLeft) {
-                    datepickerRef.value!.elementRef!.style.left = '0px';
-                    datepickerRef.value!.elementRef!.style.right = '';
+                    el.style.left = '0px';
+                    el.style.right = '';
                 } else if (isRight) {
-                    datepickerRef.value!.elementRef!.style.left = '';
-                    datepickerRef.value!.elementRef!.style.right = '0px';
+                    el.style.left = '';
+                    el.style.right = '0px';
                 }
                 if (isTop) {
-                    datepickerRef.value!.elementRef!.style.top = '100%';
-                    datepickerRef.value!.elementRef!.style.bottom = '';
+                    el.style.top = '100%';
+                    el.style.bottom = '';
                 } else if (isBottom) {
-                    datepickerRef.value!.elementRef!.style.top = '';
-                    datepickerRef.value!.elementRef!.style.bottom = '100%';
+                    el.style.top = '';
+                    el.style.bottom = '100%';
                 }
             }
         });
@@ -274,8 +280,8 @@ onMounted(() => {
 });
 onBeforeUnmount(() => {
     if (props.type === 'date') {
-        if (datePickerScrollObserver.value) {
-            datePickerScrollObserver.value.unobserve(datepickerRef.value!.elementRef!);
+        if (datePickerScrollObserver.value && datepickerRef.value?.elementRef) {
+            datePickerScrollObserver.value.unobserve(datepickerRef.value.elementRef);
         }
     }
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,7 +3,6 @@ import MiButton from '@/components/basic/Button.vue';
 import MiAutocomplete from '@/components/controls/Autocomplete.vue';
 import MiCheckbox from '@/components/controls/Checkbox.vue';
 import MiCheckboxGroup from '@/components/controls/CheckboxGroup.vue';
-import MiDatePicker from '@/components/controls/DatePicker.vue';
 import MiField from '@/components/controls/Field.vue';
 import MiRadio from '@/components/controls/Radio.vue';
 import MiRadioGroup from '@/components/controls/RadioGroup.vue';
@@ -41,7 +40,6 @@ export const componentNameMap = {
     MiAutocomplete: { name: 'MiAutocomplete' as const, component: MiAutocomplete },
     MiCheckbox: { name: 'MiCheckbox' as const, component: MiCheckbox },
     MiCheckboxGroup: { name: 'MiCheckboxGroup' as const, component: MiCheckboxGroup },
-    MiDatePicker: { name: 'MiDatePicker' as const, component: MiDatePicker },
     MiField: { name: 'MiField' as const, component: MiField },
     MiRadio: { name: 'MiRadio' as const, component: MiRadio },
     MiRadioGroup: { name: 'MiRadioGroup' as const, component: MiRadioGroup },
@@ -80,7 +78,6 @@ export {
     MiAutocomplete,
     MiCheckbox,
     MiCheckboxGroup,
-    MiDatePicker,
     MiField,
     MiRadio,
     MiRadioGroup,
@@ -120,7 +117,6 @@ declare module 'vue' {
         MiAutocomplete: typeof MiAutocomplete;
         MiCheckbox: typeof MiCheckbox;
         MiCheckboxGroup: typeof MiCheckboxGroup;
-        MiDatePicker: typeof MiDatePicker;
         MiField: typeof MiField;
         MiRadio: typeof MiRadio;
         MiRadioGroup: typeof MiRadioGroup;

--- a/src/components/nuxt-map.ts
+++ b/src/components/nuxt-map.ts
@@ -5,7 +5,6 @@ export const miComponentList = [
     { name: 'MiAutocomplete', export: 'MiAutocomplete', filePath: 'minazuki-ui' },
     { name: 'MiCheckbox', export: 'MiCheckbox', filePath: 'minazuki-ui' },
     { name: 'MiCheckboxGroup', export: 'MiCheckboxGroup', filePath: 'minazuki-ui' },
-    { name: 'MiDatePicker', export: 'MiDatePicker', filePath: 'minazuki-ui' },
     { name: 'MiField', export: 'MiField', filePath: 'minazuki-ui' },
     { name: 'MiRadio', export: 'MiRadio', filePath: 'minazuki-ui' },
     { name: 'MiRadioGroup', export: 'MiRadioGroup', filePath: 'minazuki-ui' },

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -1,0 +1,13 @@
+import type { App } from 'vue';
+import MiDatePicker from '@/components/controls/DatePicker.vue';
+import VueDatePicker from '@vuepic/vue-datepicker';
+import '@vuepic/vue-datepicker/dist/main.css';
+
+export { MiDatePicker, VueDatePicker };
+
+export default {
+    install(app: App) {
+        app.component('MiDatePicker', MiDatePicker);
+        app.component('VueDatePicker', VueDatePicker);
+    }
+};

--- a/src/generate-component-index.js
+++ b/src/generate-component-index.js
@@ -4,6 +4,9 @@ import path from 'path';
 const normalizePath = (p) => p.replace(/\\/g, '/');
 const getBaseName = (filePath) => path.basename(filePath, path.extname(filePath));
 
+// メインエントリから除外するコンポーネント（サブエントリポイントで提供）
+const EXCLUDED_COMPONENTS = ['DatePicker'];
+
 // --- components ---
 const componentFilePaths = fs
     .readdirSync('./src/components', { recursive: true })
@@ -19,6 +22,7 @@ let nuxtListContent = '';
 
 componentFilePaths.forEach((filePath) => {
     const name = getBaseName(filePath);
+    if (EXCLUDED_COMPONENTS.includes(name)) return;
     importContent += `import Mi${name} from '@/components/${filePath}';\n`;
     componentNameMapContent += `    Mi${name}: { name: 'Mi${name}' as const, component: Mi${name} },\n`;
     exportContent += `    Mi${name},\n`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import '@/assets/css/style.css';
 import '@/assets/css/override.css';
 
 import type { App } from 'vue';
-import useFormData from '@/composables/useFormData';
 import useNotification from '@/composables/useNotification';
 import useTheme, {
     type MiThemeOverride,
@@ -12,15 +11,13 @@ import useTheme, {
     detectLegacyThemeOptions
 } from '@/composables/useTheme';
 import useOutsideClick from './directives/useOutsideClick';
-import VueDatePicker from '@vuepic/vue-datepicker';
-import '@vuepic/vue-datepicker/dist/main.css';
 import { componentNameMap } from '@/components';
 
 export * from '@/components';
 export * from '@/composables';
 export * from '@/directives';
 export { default as initValidate } from '@/plugins/init-validate';
-export { useFormData, useNotification, useTheme };
+export { useNotification, useTheme };
 
 export default {
     install(app: App, options?: { theme?: MiThemeOverride; themeId?: ThemeId }) {
@@ -35,15 +32,11 @@ export default {
         }
 
         // composables
-        app.provide('useFormData', useFormData);
         app.provide('useNotification', useNotification);
         app.provide('useTheme', useTheme);
 
         // directives
         app.provide('useOutsideClick', useOutsideClick);
-
-        // component
-        app.component('VueDatePicker', VueDatePicker);
 
         const { currentTheme, overrideTheme, setTheme } = useTheme();
         if (options?.theme) {

--- a/src/nuxt/module.ts
+++ b/src/nuxt/module.ts
@@ -29,6 +29,8 @@ export interface ModuleOptions {
      * - true: Vue3 同等の全コンポーネント一括グローバル登録（互換性優先）
      */
     install?: boolean;
+    /** @vuepic/vue-datepicker の auto-import と CSS 注入（default: false） */
+    datepicker?: boolean;
 }
 
 // TS2742 回避: @nuxt/schema への直接参照を避けるためローカル型でラップ
@@ -51,7 +53,8 @@ const _module = defineNuxtModule<ModuleOptions>({
         themeId: 'light',
         cookieName: 'themeId',
         cookieMaxAge: 60 * 60 * 24 * 365,
-        install: false
+        install: false,
+        datepicker: false
     },
     setup(options, nuxt) {
         const legacyThemeMessage = detectLegacyThemeOptions(options);
@@ -77,10 +80,12 @@ const _module = defineNuxtModule<ModuleOptions>({
             nuxt.options.vite.optimizeDeps.exclude.push('minazuki-ui');
         }
 
-        // vue-datepicker の transpile（Nuxt 3 + CJS 対応）
-        nuxt.options.build.transpile = nuxt.options.build.transpile ?? [];
-        if (!nuxt.options.build.transpile.includes('@vuepic/vue-datepicker')) {
-            nuxt.options.build.transpile.push('@vuepic/vue-datepicker');
+        // vue-datepicker の transpile（datepicker 有効時のみ）
+        if (options.datepicker) {
+            nuxt.options.build.transpile = nuxt.options.build.transpile ?? [];
+            if (!nuxt.options.build.transpile.includes('@vuepic/vue-datepicker')) {
+                nuxt.options.build.transpile.push('@vuepic/vue-datepicker');
+            }
         }
 
         if (options.autoImport) {
@@ -92,12 +97,19 @@ const _module = defineNuxtModule<ModuleOptions>({
                     filePath: component.filePath
                 });
             }
-            // VueDatePicker も auto-import
-            addComponent({
-                name: 'VueDatePicker',
-                export: 'default',
-                filePath: '@vuepic/vue-datepicker'
-            });
+            // datepicker 有効時のみ auto-import
+            if (options.datepicker) {
+                addComponent({
+                    name: 'MiDatePicker',
+                    export: 'MiDatePicker',
+                    filePath: 'minazuki-ui/datepicker'
+                });
+                addComponent({
+                    name: 'VueDatePicker',
+                    export: 'default',
+                    filePath: '@vuepic/vue-datepicker'
+                });
+            }
 
             // composables / directives auto-import
             for (const composable of miComposableList) {

--- a/src/nuxt/runtime/plugin.ts
+++ b/src/nuxt/runtime/plugin.ts
@@ -2,7 +2,7 @@
 // @ts-ignore - #imports は Nuxt ランタイムの仮想モジュール（library build 時は未解決）
 import { defineNuxtPlugin, useCookie, useRuntimeConfig } from '#imports';
 import { watch } from 'vue';
-import MinazukiUi, { useTheme, useFormData, useNotification, useOutsideClick } from 'minazuki-ui';
+import MinazukiUi, { useTheme, useNotification, useOutsideClick } from 'minazuki-ui';
 import type { ThemeId, MiThemeOverride } from 'minazuki-ui';
 
 type MinazukiUiConfig = {
@@ -38,7 +38,6 @@ export default defineNuxtPlugin((nuxtApp: { vueApp: import('vue').App }) => {
         }
         setTheme(currentTheme.value);
 
-        nuxtApp.vueApp.provide('useFormData', useFormData);
         nuxtApp.vueApp.provide('useNotification', useNotification);
         nuxtApp.vueApp.provide('useTheme', useTheme);
         nuxtApp.vueApp.provide('useOutsideClick', useOutsideClick);

--- a/src/test/components/controls/Field.spec.ts
+++ b/src/test/components/controls/Field.spec.ts
@@ -1,10 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { nextTick, h, defineComponent } from 'vue';
 import { mount, flushPromises } from '@vue/test-utils';
 import { z } from 'zod';
 import { Form as VeeForm } from 'vee-validate';
 import Field from '@/components/controls/Field.vue';
-import DatePicker from '@/components/controls/DatePicker.vue';
 import FieldFrame from '@/components/inner-parts/FieldFrame.vue';
 import useFormData from '@/composables/useFormData';
 import { uniqueFieldName } from '@/test/utils/uniqueFieldName';
@@ -19,6 +18,10 @@ const settleValidation = async () => {
 };
 
 describe('Field', () => {
+    beforeAll(async () => {
+        await import('@/components/controls/DatePicker.vue');
+    });
+
     it('label が表示される', () => {
         const wrapper = mount(Field, { props: { label: 'メールアドレス' } });
         expect(wrapper.find('.label').text()).toBe('メールアドレス');
@@ -256,14 +259,19 @@ describe('Field', () => {
     });
 
     it('type="date" のとき unmount で IntersectionObserver.unobserve が呼ばれる', async () => {
+        const mockObserve = vi.fn();
         const mockUnobserve = vi.fn();
         vi.stubGlobal('IntersectionObserver', vi.fn(() => ({
-            observe: vi.fn(),
+            observe: mockObserve,
             disconnect: vi.fn(),
             unobserve: mockUnobserve
         })));
         const wrapper = mount(Field, { props: { type: 'date' } });
+        await flushPromises();
+        await wrapper.find('button.input').trigger('click');
+        await flushPromises();
         await nextTick();
+        expect(mockObserve).toHaveBeenCalled();
         wrapper.unmount();
         expect(mockUnobserve).toHaveBeenCalled();
         vi.unstubAllGlobals();
@@ -404,10 +412,14 @@ describe('Field', () => {
 
     it('type="date" のとき DatePicker が update:modelValue を emit すると value が更新される', async () => {
         const wrapper = mount(Field, { props: { type: 'date' } });
-        await nextTick();
+        await flushPromises();
         await wrapper.find('button.input').trigger('click');
+        await flushPromises();
         await nextTick();
-        const datePicker = wrapper.findComponent(DatePicker);
+        await flushPromises();
+        await flushPromises();
+        await nextTick();
+        const datePicker = wrapper.findComponent({ name: 'DatePicker' });
         await datePicker.vm.$emit('update:modelValue', '20240115');
         await nextTick();
         expect(wrapper.find('button.input span').text()).not.toBe('');

--- a/vite.datepicker.config.ts
+++ b/vite.datepicker.config.ts
@@ -1,0 +1,71 @@
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import dts from 'vite-plugin-dts'
+import { resolve } from 'path';
+
+const externalPackages = [
+    'vue',
+    'unhead',
+    '@unhead/vue',
+    '@vee-validate/rules',
+    '@vee-validate/zod',
+    '@vuepic/vue-datepicker',
+    'dayjs',
+    'i18next',
+    'lucide-vue-next',
+    'vee-validate',
+    'vue-router',
+    'zod',
+    'zod-i18n-map',
+];
+
+const externalRegexps = externalPackages.map(
+    (pkg) => new RegExp(`^${pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(/.*)?$`)
+);
+
+const srcDir = fileURLToPath(new URL('./src', import.meta.url));
+
+export default defineConfig({
+    build: {
+        minify: false,
+        rollupOptions: {
+            input: resolve(__dirname, './src/datepicker.ts'),
+            external: (id, importer) => {
+                if (externalRegexps.some(re => re.test(id))) return true;
+                if (importer && id.startsWith(srcDir) && !id.endsWith('datepicker.ts')) return true;
+                return false;
+            },
+            preserveEntrySignatures: 'strict',
+            output: {
+                format: 'es',
+                dir: './dist',
+                entryFileNames: '[name].js',
+                exports: 'named',
+                paths: (id) => {
+                    if (id.startsWith(srcDir)) {
+                        const relative = id.slice(srcDir.length);
+                        return '.' + relative.replace(/\.vue$/, '.vue.js').replace(/\.ts$/, '.js');
+                    }
+                    return id;
+                },
+            },
+        },
+        outDir: './dist',
+        emptyOutDir: false,
+    },
+    plugins: [
+        vue(),
+        dts({
+            tsconfigPath: 'tsconfig.build.json',
+            outDir: './dist',
+            include: ['src/datepicker.ts'],
+            entryRoot: 'src',
+        }),
+    ],
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./src', import.meta.url))
+        }
+    },
+});


### PR DESCRIPTION
## Summary

- `@vuepic/vue-datepicker` (182KB) をメインエントリから分離し、`minazuki-ui/datepicker` サブエントリポイントとして提供
- DatePicker を使用しない消費側のバンドルサイズを自動的に削減
- `@vuepic/vue-datepicker`, `@vee-validate/rules`, `@vee-validate/zod` を optional peerDependency に変更

## 破壊的変更

| 変更内容 | 移行方法 |
|---|---|
| `MiDatePicker` / `VueDatePicker` がメインプラグインで登録されなくなる | Vue: `app.use(MinazukiUiDatepicker)` を追加<br>Nuxt: `minazukiUi: { datepicker: true }` を設定 |
| `useFormData` が `app.provide()` されなくなる | `import { useFormData } from 'minazuki-ui'` で直接インポート（変更前も動作） |
| `@vuepic/vue-datepicker` が optional peerDependency に変更 | DatePicker を使う場合のみインストール |

## 主な変更ファイル

- `src/datepicker.ts` — 新規サブエントリポイント
- `vite.datepicker.config.ts` — datepicker 用ビルド設定（メインビルドの出力を参照する薄いラッパー）
- `src/components/controls/Field.vue` — DatePicker を `defineAsyncComponent` で遅延読み込みに変更
- `src/nuxt/module.ts` — `datepicker` オプション追加（default: false）
- `package.json` — `./datepicker` export 追加、peerDependenciesMeta 設定

## Test plan

- [x] 全796テスト通過
- [x] lint / type-check クリア
- [x] `dist/index.js` に vue-datepicker への参照がないことを確認
- [x] `dist/datepicker.js` が MiDatePicker / VueDatePicker を正しくエクスポート
- [x] Playground 3環境（Vue 3 / Nuxt 3 / Nuxt 4）で動作確認済み

Closes #870

Generated with [Claude Code](https://claude.ai/code)