### PR TITLE
chore: engines.node の記法を修正し下限を Node 22 に引き上げる

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": ">=20.5.*"
+    "node": ">=22.13"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 概要

`engines.node` の記法が `>=20.5.*` という semver として不正な形になっていたため修正します。あわせて Node 20 が 2026-04-30 に EOL を迎えているため、下限をサポート継続中の Node 22 (Jod) に引き上げます。

| バージョン | 状態 | EOL |
| --- | --- | --- |
| Node 20 (Iron) | EOL 済み | 2026-04-30 |
| Node 22 (Jod) | Maintenance LTS | 2027-04-30 |
| Node 24 (Krypton) | Active LTS | 2028-04-30 |

## 変更内容

- `engines.node`: `>=20.5.*` → `>=22.13`

CI は既に Node 24 で動作しているため（`.github/actions/setup/action.yml` の default が `24`、`release-package.yml` も `'24'` を明示）、workflow の変更はありません。

## 方針について

本ライブラリは公開パッケージのため、`engines` は**下限**として据え置き寄りにし、Node 24 までは上げていません。消費側（shigurezuki 等）が Node 24 でも、下限指定であるため取り込みに支障はありません。

`@types/node` も 22 系（`^22.19.19`）のまま維持しています。24 系へ更新すると、`@vue/tsconfig` が Vite のブラウザターゲットに合わせて `lib: ["ES2020", ...]` を意図的に固定している影響で、`.at()` を使うテストが TS2550 になるためです（従来は `@types/node` 22 が暗黙的に lib を引き上げていました）。

### 消費側への影響がないことの確認

- `engines` は下限指定のため、Node 24 の消費側から見て制約にならない
- `@types/node` は devDependencies のみで、`files` に含まれず publish されない
- 公開される `dist/*.d.ts` に Node 型への参照（`NodeJS.` / `@types/node` / `reference types="node"` / `Buffer` / `node:`）が 1 件も存在しないことを確認済み
- 実際の消費側である shigurezuki（`minazuki-ui: ^3.0.0`）が Node 24.19.0 でビルド成功

## 検証

Node 24.19.0（fnm）で以下を確認済みです。

- `pnpm lint` / `pnpm type-check` / `pnpm test:run` / `pnpm build` すべて成功

ビルド時に TS6307 が 5 件出ますが、Node 22.14.0 でのベースライン計測でも同一の 5 件・同一の終了コード 0 だったため、`tsconfig.build.json` 由来の既存事象であり Node 24 起因ではないと切り分けています（本 PR では扱いません）。

## 未解決事項

- 既存の TS6307（`tsconfig.build.json` 由来）は別途対応。
- devDependencies に残る `@tsconfig/node18` は実効影響がないため本 PR では触れていません。

Generated with [Claude Code](https://claude.ai/code)
